### PR TITLE
extend renumber test case to include unreferenced nodes in relations

### DIFF
--- a/test/renumber/input-sorted.osm
+++ b/test/renumber/input-sorted.osm
@@ -17,6 +17,7 @@
   </way>
   <relation id="30" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
     <member type="node" ref="12" role="m1"/>
+    <member type="node" ref="3" role="m1"/>
     <member type="way" ref="20" role="m2"/>
   </relation>
 </osm>

--- a/test/renumber/output-change.osc
+++ b/test/renumber/output-change.osc
@@ -7,12 +7,12 @@
     <node id="4" version="2" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="2" lat="4" lon="1"/>
   </delete>
   <create>
-    <node id="5" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="2" lat="2" lon="2"/>
+    <node id="6" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="2" lat="2" lon="2"/>
   </create>
   <modify>
     <way id="2" version="2" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="2">
       <nd ref="3"/>
-      <nd ref="5"/>
+      <nd ref="6"/>
       <tag k="xyz" v="new"/>
     </way>
   </modify>

--- a/test/renumber/output-sorted.osm
+++ b/test/renumber/output-sorted.osm
@@ -17,6 +17,7 @@
   </way>
   <relation id="1" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
     <member type="node" ref="3" role="m1"/>
+    <member type="node" ref="5" role="m1"/>
     <member type="way" ref="1" role="m2"/>
   </relation>
 </osm>


### PR DESCRIPTION
Unreferenced nodes will be ignored in subsequent calls to renumber if they have an id that is lower than the highest number in the node list. This tests this condition.