### PR TITLE
Fix test failure on big endian architectures.

### DIFF
--- a/test/fileinfo/CMakeLists.txt
+++ b/test/fileinfo/CMakeLists.txt
@@ -12,7 +12,13 @@ endfunction()
 
 #-----------------------------------------------------------------------------
 
-check_fileinfo(fi1 "--extended" fi1.osm fi1-result.txt)
+include(TestBigEndian)
+test_big_endian(BIG_ENDIAN)
 
+if(${BIG_ENDIAN})
+    check_fileinfo(fi1 "--extended" fi1.osm fi1-result-be.txt)
+else(${BIG_ENDIAN})
+    check_fileinfo(fi1 "--extended" fi1.osm fi1-result.txt)
+endif(${BIG_ENDIAN})
 
 #-----------------------------------------------------------------------------

--- a/test/fileinfo/fi1-result-be.txt
+++ b/test/fileinfo/fi1-result-be.txt
@@ -1,0 +1,27 @@
+File:
+  Name: fileinfo/fi1.osm
+  Format: XML
+  Compression: none
+  Size: 438
+Header:
+  Bounding boxes:
+  With history: no
+  Options:
+    generator=testdata
+    version=0.6
+Data: 
+  Bounding box: (1,1,1,3)
+  Timestamps:
+    First: 2015-01-01T01:00:00Z
+    Last: 2015-01-01T04:00:00Z
+  Objects ordered (by type and id): yes
+  Multiple versions of same object: no
+  CRC32: 1e1e05ec
+  Number of changesets: 0
+  Number of nodes: 3
+  Number of ways: 0
+  Number of relations: 0
+  Largest changeset ID: 0
+  Largest node ID: 4
+  Largest way ID: 0
+  Largest relation ID: 0


### PR DESCRIPTION
The CRC checksum is different on big endian architectures like mips, powerpc & s390x.
On these architectures the fileinfo-fi1 test failed during the Debian package build:
```
 6/25 Test  #6: fileinfo-fi1 .....................***Failed    0.04 sec
Executing: /«PKGBUILDDIR»/obj-powerpc-linux-gnu/src/osmium fileinfo --extended fileinfo/fi1.osm
CMake Error at /«PKGBUILDDIR»/cmake/run_test_compare_output.cmake:64 (message):
  Test output does not match 'fileinfo/fi1-result.txt'.  Output is in
  'test.stdout'.
```
Build logs: [mips](https://buildd.debian.org/status/fetch.php?pkg=osmium-tool&arch=mips&ver=1.1.1-1&stamp=1437477985), [powerpc](https://buildd.debian.org/status/fetch.php?pkg=osmium-tool&arch=powerpc&ver=1.1.1-1&stamp=1437459055), [s390x](https://buildd.debian.org/status/fetch.php?pkg=osmium-tool&arch=s390x&ver=1.1.1-1&stamp=1437478617)

On the respective porter boxes the diff between `test.stdout` and the expected results show the different checksum:
```
$ diff -u test/fileinfo/fi1-result.txt obj-s390x-linux-gnu/test/fileinfo/test.stdout
--- test/fileinfo/fi1-result.txt        2015-07-04 14:34:21.000000000 +0000
+++ obj-s390x-linux-gnu/test/fileinfo/test.stdout       2015-07-21 18:04:13.671215317 +0000
@@ -16,7 +16,7 @@
     Last: 2015-01-01T04:00:00Z
   Objects ordered (by type and id): yes
   Multiple versions of same object: no
-  CRC32: 7cb270e8
+  CRC32: 1e1e05ec
   Number of changesets: 0
   Number of nodes: 3
   Number of ways: 0
```
The CRC32 value is consistent across the other big endian architectures.

I've added a big endian specific result file, and updated the CMake configuration to use it on big endian architectures.