### PR TITLE
Stop list items running together

### DIFF
--- a/man/osmium-apply-changes.md
+++ b/man/osmium-apply-changes.md
@@ -69,8 +69,10 @@ so the data has to fit in there!
 
 0
   ~ if everything went alright,
+
 1
   ~ if there was an error processing the data, or
+
 2
   ~ if there was a problem with the command line arguments.
 

--- a/man/osmium-cat.md
+++ b/man/osmium-cat.md
@@ -62,8 +62,10 @@ can be used to convert OSM files from one format into another.
 
 0
   ~ if everything went alright,
+
 1
   ~ if there was an error processing the data, or
+
 2
   ~ if there was a problem with the command line arguments.
 

--- a/man/osmium-check-refs.md
+++ b/man/osmium-check-refs.md
@@ -57,9 +57,11 @@ nodes in order of ID, then ways in order of ID, then relations in order of ID.
 
 0
   ~ if all references are satisfied
+
 1
   ~ if there was an error processing the data or some references were not
     satisfied, or
+
 2
   ~ if there was a problem with the command line arguments.
 

--- a/man/osmium-file-formats.md
+++ b/man/osmium-file-formats.md
@@ -61,10 +61,13 @@ Here are some examples:
 
 pbf
 :   PBF format.
+
 osm.bz2
 :   XML format, compressed with bzip2.
+
 osc.gz
 :   OSM change file, compressed with gzip.
+
 osm.gz,xml_change_format=true
 :   OSM change file, compressed with gzip.
 

--- a/man/osmium-fileinfo.md
+++ b/man/osmium-fileinfo.md
@@ -115,8 +115,10 @@ are in the format `(xmin, ymin, xmax, ymax)`.
 
 0
   ~ if everything went alright,
+
 1
   ~ if there was an error processing the data, or
+
 2
   ~ if there was a problem with the command line arguments.
 

--- a/man/osmium-getid.md
+++ b/man/osmium-getid.md
@@ -54,8 +54,10 @@ Get objects with the given IDs from the input and write them to the output
 
 0
   ~ if all IDs were found
+
 1
   ~ if there was an error processing the data or not all IDs were found, or
+
 2
   ~ if there was a problem with the command line arguments.
 

--- a/man/osmium-merge-changes.md
+++ b/man/osmium-merge-changes.md
@@ -61,8 +61,10 @@ in what order the change files are given or in what order they contain the data.
 
 0
   ~ if everything went alright,
+
 1
   ~ if there was an error processing the data, or
+
 2
   ~ if there was a problem with the command line arguments.
 

--- a/man/osmium-renumber.md
+++ b/man/osmium-renumber.md
@@ -76,8 +76,10 @@ IDs.
 
 0
   ~ if everything went alright,
+
 1
   ~ if there was an error processing the data, or
+
 2
   ~ if there was a problem with the command line arguments.
 

--- a/man/osmium-time-filter.md
+++ b/man/osmium-time-filter.md
@@ -65,8 +65,10 @@ The format for the timestamps is "yyyy-mm-ddThh:mm::ssZ".
 
 0
   ~ if everything went alright,
+
 1
   ~ if there was an error processing the data, or
+
 2
   ~ if there was a problem with the command line arguments.
 

--- a/man/osmium.md
+++ b/man/osmium.md
@@ -29,20 +29,28 @@ Run **osmium help** *COMMAND* to get more information about a command.
 
 apply-changes
 :   apply OSM change file(s) to OSM data file
+
 cat
 :   concatenate OSM files and convert to different formats
+
 check-refs
 :   check referential integrity of OSM file
+
 fileinfo
 :   show information about an OSM file
+
 getid
 :   get objects from OSM file by ID
+
 help
 :   show help about commands
+
 merge-changes
 :   merge several OSM change files into one
+
 renumber
 :   renumber object IDs
+
 time-filter
 :   filter OSM data by time from a history file
 


### PR DESCRIPTION
Add blank lines between list items in manual pages to stop them running together when converted to man format.

At least for definition lists this seems to be required, per http://pandoc.org/README.html#definition-lists we have "Note that space between items in a definition list is required".

It's not as clear to me that the numbered lists need it, but without it pandoc 1.13.2 on my machine seems to run them together into a single item in the output.