### PR TITLE
Do not allow git to change line endings for test files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.osm -crlf
+*.osc -crlf
+*.opl -crlf
+*.osh -crlf
+*-result.txt -crlf


### PR DESCRIPTION
Now most of the tests fail on Windows without addtional Git setup. This happens because reference .osm files line endings are changed by Git when cloning. 
This patch tells Git to keep osm,osc,opl and *-result.txt files with Unix line engings, working with source files as usual.