### PR TITLE
Fix spelling errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Remove license thats not applicable from LICENSE-rapidjson.txt.
+- Remove license that's not applicable from LICENSE-rapidjson.txt.
 - Renumbering didn't work properly in some cases.
 - Fix error checking in renumber command.
 

--- a/man/osmium-check-refs.md
+++ b/man/osmium-check-refs.md
@@ -49,7 +49,7 @@ change files.
 needs enough main memory to store all temporary data.
 
 Largest memory need will be about 1 bit for each node ID, for a full planet
-thats roughly 500 MB these days (Summer 2015). With the **-r**,
+that's roughly 500 MB these days (Summer 2015). With the **-r**,
 **--check-relations** option memory use will be a bit bigger.
 
 


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the latest osmium-tool build:
* thats -> that's
