### PR TITLE
Fix 'ouput' error, replace with 'output'.

### DIFF
--- a/man/osmium-getid.md
+++ b/man/osmium-getid.md
@@ -51,7 +51,7 @@ only used to detect which objects to get. This might matter if there are
 different object versions in the different files.
 
 The *OSM-FILE* can not be a history file unless the **-H**, **--history**
-option is used. Then all versions of the objects will be copied to the ouput.
+option is used. Then all versions of the objects will be copied to the output.
 
 If referenced objects are missing from the input file, the type and IDs
 of those objects is written out to *stderr* at the end of the program unless


### PR DESCRIPTION
The spelling error was reported by the lintian QA tool for the Debian package build of 1.3.1.