### PR TITLE
Fix spelling errors.

### DIFF
--- a/man/osmium-derive-changes.md
+++ b/man/osmium-derive-changes.md
@@ -18,7 +18,7 @@ applied on *OSM-FILE1* to re-create *OSM-FILE2*.
 Objects in both input files must be sorted by type, ID, and version. The first
 input file must be from a point in time before the second input file.
 
-For this command to create a proper chnage file you have to set the
+For this command to create a proper change file you have to set the
 **--output** option or **--output-format** option in a way that it will
 generate an .osc file, typically by using something like '-o out.osc.gz'.
 You can create any other OSM file format, but that is usually not what you

--- a/man/osmium-diff.md
+++ b/man/osmium-diff.md
@@ -40,12 +40,12 @@ compact
     file, respectively.
 
 opl
-:   The usual OPL format with all lines preceeded by space (' '), minus
+:   The usual OPL format with all lines preceded by space (' '), minus
     ('-'), or plus ('+') characters depending on whether the object is in both,
     the first, or the second file.
 
 debug
-:   The usual debug format with all lines preceeded by space (' '), minus
+:   The usual debug format with all lines preceded by space (' '), minus
     ('-'), or plus ('+') characters depending on whether the object is in both,
     the first, or the second file. Color support can be enabled ('debug,color').
 

--- a/man/osmium-merge.md
+++ b/man/osmium-merge.md
@@ -46,7 +46,7 @@ correctly.
 # MEMORY USAGE
 
 **osmium merge** doesn't keep a lot of data in memory, but if you are merging
-many files, the buffers might take a noticable amount of memory.
+many files, the buffers might take a noticeable amount of memory.
 
 
 # EXAMPLES


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the new manpages:

 * chnage    -> change
 * preceeded -> preceded
 * noticable -> noticeable