### PR TITLE
Add support for building with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+build/
+libosmium/
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y \
+    g++ \
+    libprotozero-dev \
+    libutfcpp-dev \
+    rapidjson-dev \
+    libboost-program-options-dev \
+    libboost-dev \
+    libbz2-dev \
+    zlib1g-dev \
+    libexpat1-dev \
+    cmake \
+    pandoc \
+    curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# cmake segfaults when run in /
+# so we have to run it in a subdirectory
+# https://gitlab.kitware.com/cmake/cmake/issues/16603
+WORKDIR /osmium
+
+COPY . .
+
+# we need a newer libosmium than the one included in the distro
+RUN mkdir -p libosmium && \
+    curl -sSL https://github.com/osmcode/libosmium/archive/v2.12.2.tar.gz | \
+    tar -v -xz -C libosmium --strip-components=1
+
+RUN mkdir build && \
+    cd build && \
+    cmake -DOSMIUM_INCLUDE_DIR=../libosmium/include .. -DCMAKE_BUILD_TYPE=Release && \
+    make
+
+ENTRYPOINT ["build/osmium"]
+CMD [ "help" ]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ To set the build type call cmake with `-DCMAKE_BUILD_TYPE=type`. Possible
 values are empty, Debug, Release, RelWithDebInfo, MinSizeRel, and Dev. The
 default is RelWithDebInfo.
 
+## Docker
+
+You can use Docker to build and run `osmium`:
+
+    docker build . -t osmium
+
+    docker run -it osmium help # or any of the subcommands that osmium accepts
+
 
 ## Documentation
 


### PR DESCRIPTION
This PR allows users to build/run the project with Docker.

It also adds instructions for it in the `README`.