### PR TITLE
Only install manpage directories, not CMake files.

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -68,7 +68,7 @@ if(PANDOC)
     add_man_page(5 osmium-file-formats)
     add_man_page(5 osmium-index-types)
 
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} DESTINATION share)
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man1 ${CMAKE_CURRENT_BINARY_DIR}/man5 DESTINATION share/man)
 
     add_custom_target(man ALL DEPENDS ${ALL_MAN_PAGES})
 else()


### PR DESCRIPTION
The changes in b173efcdcf17981a6652c1fb1797d400a0df9a8c cause the generated CMake files to be installed in `/usr/share/man` too.