### PR TITLE
Add Alpine-Linux based Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM alpine:3.6
+
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
+WORKDIR /usr/src/apps
+
+RUN apk add --no-cache \
+        boost-dev \
+        bzip2-dev \
+        cmake \
+        expat-dev \
+        g++ \
+        gdal-dev \
+        geos-dev \
+        git \
+        make \
+        proj4-dev \
+        sparsehash \
+        zlib-dev && \
+    git clone https://github.com/osmcode/libosmium.git && \
+        cd libosmium && \
+        mkdir build && \
+        cd build && \
+        cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_EXAMPLES=OFF .. && \
+        make
+
+COPY . /usr/src/apps/osmium
+
+WORKDIR /usr/src/apps/osmium
+RUN mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=MinSizeRel .. && \
+    make && \
+    make install
+
+RUN apk del git cmake make
+
+ENTRYPOINT ["osmium"]
+
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ To set the build type call cmake with `-DCMAKE_BUILD_TYPE=type`. Possible
 values are empty, Debug, Release, RelWithDebInfo, MinSizeRel, and Dev. The
 default is RelWithDebInfo.
 
+### Building with Docker
+
+Osmium can be build and used as a Docker container. It will also build `libosmium`
+from scratch as it is required for `osmium-tool`.
+
+    docker build -t osmcode/osmium-tool -f Dockerfile .
+
+If everything worked well, running `osmium-tool` is now as simple as:
+
+    docker run -it osmcode/osmium-tool:latest --help
 
 ## Documentation
 


### PR DESCRIPTION
This PR enables to run `osmium-tool` as a Docker container.
The image is based on Alpine Linux and includes `libosmium` as well.

_Note: It might be cleaner to have a `libosmium` Docker container and build from that one._