### PR TITLE
[bugfix] Write an object of the correct type if a deletion is detected.

### DIFF
--- a/src/command_derive_changes.cpp
+++ b/src/command_derive_changes.cpp
@@ -118,12 +118,28 @@ void CommandDeriveChanges::write_deleted(osmium::io::Writer& writer, osmium::OSM
         writer(object);
     } else {
         using namespace osmium::builder::attr; // NOLINT
-        osmium::builder::add_node(m_buffer,
-            _deleted(),
-            _id(object.id()),
-            _version(object.version()),
-            _timestamp(object.timestamp())
-        );
+        if (object.type() == osmium::item_type::node) {
+            osmium::builder::add_node(m_buffer,
+                _deleted(),
+                _id(object.id()),
+                _version(object.version()),
+                _timestamp(object.timestamp())
+            );
+        } else if (object.type() == osmium::item_type::way) {
+            osmium::builder::add_way(m_buffer,
+                 _deleted(),
+                 _id(object.id()),
+                 _version(object.version()),
+                 _timestamp(object.timestamp())
+             );
+        } else if (object.type() == osmium::item_type::relation) {
+            osmium::builder::add_relation(m_buffer,
+                 _deleted(),
+                 _id(object.id()),
+                 _version(object.version()),
+                 _timestamp(object.timestamp())
+             );
+        }
         writer(m_buffer.get<osmium::OSMObject>(0));
         m_buffer.clear();
     }


### PR DESCRIPTION
This commit fixes a bug of the derive-changes command if it is used without `--keep-details`. If you don't use `--keep-details` a deletion of any object is written as a deletion of a node of the same ID.

Example to reproduce the bug:

```sh
wget http://download.geofabrik.de/europe/germany/bremen-180130.osm.pbf
http://download.geofabrik.de/europe/germany/bremen-updates/000/001/775.osc.gz
osmium apply-changes -o bremen-180131.osm.pbf bremen-180130.osm.pbf 775.osc.gz
osmium derive-changes -o wrong-diff.osc bremen-180130.osm.pbf bremen-180131.osm.pbf
```

The diff file downloaded from Geofabrik contains one deletion:

```xml
  </modify>
  <delete>
    <relation id="7948190" version="2" timestamp="2018-01-30T20:11:48Z" uid="61005" user="nkbre" changeset="55906798">
      <member type="way" ref="162010892" role=""/>
      <member type="way" ref="27683186" role=""/>
      <tag k="description" v="Kulturdenkmal, siehe http://wiki.openstreetmap.org/wiki/Bremen/Kulturdenkm%C3%A4ler"/>
      <tag k="heritage" v="4"/>
      <tag k="heritage:operator" v="lfd"/>
      <tag k="lfd:criteria" v="ED"/>
      <tag k="ref:lfd" v="0948,T"/>
      <tag k="type" v="site"/>
      <tag k="website" v="http://denkmalpflege.bremen.de/sixcms/detail.php?template=20_denkmal_wrapper_d&amp;amp;obj=00000948,T"/>
      <tag k="wikidata" v="Q41347364"/>
      <tag k="wikipedia" v="de:Ichons Park und Landhaus Caesar-Ichon"/>
    </relation>
  </delete>
</osmChange>
```

The diff file we produced contains a different deletion:

```xml
  </modify>
  <delete>
    <relation id="7948190" version="2" timestamp="2018-01-30T20:11:48Z"/>
  </delete>
</osmChange>

Geofabrik uses `osmium derive-changes --keep-details …` to produce the diffs of the extracts and is not affected by this bug.