### PR TITLE
Apply diffs without timestamps on input files with timestamp, version and even more metadata fields

### DIFF
--- a/src/command_apply_changes.cpp
+++ b/src/command_apply_changes.cpp
@@ -357,7 +357,7 @@ bool CommandApplyChanges::run() {
                            input.begin(),
                            input.end(),
                            output_it,
-                           osmium::object_order_type_id_reverse_version());
+                           osmium::object_order_type_id_reverse_version_without_timestamp());
         }
     }
 

--- a/test/apply-changes/CMakeLists.txt
+++ b/test/apply-changes/CMakeLists.txt
@@ -44,3 +44,6 @@ check_apply_changes(redact-metadata "--redact" input-redact-metadata.osh input-r
 # The input file has version and timestamp fields, the diff has only version fields.
 check_apply_changes(version-on-version-timestamp "" input-version+timestamp.osm input-version.osc "osm" output-version-applied-on-version+timestamp.osm)
 check_apply_changes(version-on-version-timestamp-low "--locations-on-ways" input-version+timestamp.osm input-version.osc "osm" output-version-applied-on-version+timestamp-low.osm)
+
+# The input file has all metadata fields, the diff has only version fields.
+check_apply_changes(version-on-all "" input-data.osm input-change-only-version.osc "osm" output-version-applied-on-all.osm)

--- a/test/apply-changes/CMakeLists.txt
+++ b/test/apply-changes/CMakeLists.txt
@@ -39,3 +39,8 @@ check_apply_changes(patch-old-version "--redact" input-patch-old-version.osh inp
 check_apply_changes(redact-metadata "--redact" input-redact-metadata.osh input-redact-metadata.osc "osh" output-redact-metadata.osh)
 
 #-----------------------------------------------------------------------------
+# Test the application of diffs which have only some metadata fields on files which have only some metadata fields
+#-----------------------------------------------------------------------------
+# The input file has version and timestamp fields, the diff has only version fields.
+check_apply_changes(version-on-version-timestamp "" input-version+timestamp.osm input-version.osc "osm" output-version-applied-on-version+timestamp.osm)
+check_apply_changes(version-on-version-timestamp-low "--locations-on-ways" input-version+timestamp.osm input-version.osc "osm" output-version-applied-on-version+timestamp-low.osm)

--- a/test/apply-changes/input-change-only-version.osc
+++ b/test/apply-changes/input-change-only-version.osc
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osmChange version="0.6" generator="testdata">
+  <modify>
+    <node id="11" version="2" lat="2" lon="2"/>
+  </modify>
+  <delete>
+    <node id="13" version="2" lat="4" lon="1"/>
+  </delete>
+  <create>
+    <node id="14" version="1" lat="5" lon="1"/>
+  </create>
+  <modify>
+    <way id="21" version="2">
+      <nd ref="12"/>
+      <nd ref="14"/>
+      <tag k="xyz" v="new"/>
+    </way>
+  </modify>
+</osmChange>

--- a/test/apply-changes/input-version+timestamp.osm
+++ b/test/apply-changes/input-version+timestamp.osm
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="osmium/1.7.1">
+  <node id="1" version="2" timestamp="2017-11-03T00:00:00Z" lat="50" lon="10">
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="School"/>
+  </node>
+  <node id="2" version="2" timestamp="2017-01-03T00:00:00Z" lat="50" lon="10.01"/>
+  <node id="3" version="1" timestamp="2017-01-03T00:00:00Z" lat="50" lon="10.02"/>
+  <way id="1" version="1" timestamp="2017-01-03T00:00:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <tag k="highway" v="residential"/>
+  </way>
+  <way id="2" version="1" timestamp="2017-01-03T00:00:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <tag k="highway" v="path"/>
+  </way>
+  <relation id="1" version="1" timestamp="2017-01-03T00:00:00Z">
+    <member type="node" ref="1" role="stop"/>
+    <member type="way" ref="1" role=""/>
+    <tag k="type" v="route"/>
+    <tag k="route" v="bus"/>
+  </relation>
+</osm>

--- a/test/apply-changes/input-version.osc
+++ b/test/apply-changes/input-version.osc
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osmChange version="0.6">
+  <modify>
+    <node id="1" version="3" lat="50.001" lon="10.0">
+      <tag k="highway" v="bus_stop" />
+      <tag k="name" v="School" />
+    </node>
+  </modify>
+  <delete>
+    <node id="3" version="1" visible="false"/>
+  </delete>
+  <create>
+    <node id="4" version="1" lat="50.0" lon="10.02"/>
+  </create>
+  <modify>
+    <way id="1" version="2">
+      <tag k="highway" v="residential" />
+      <nd ref="1"/>
+      <nd ref="2"/>
+      <nd ref="4"/>
+    </way>
+  </modify>
+</osmChange>

--- a/test/apply-changes/output-version-applied-on-all.osm
+++ b/test/apply-changes/output-version-applied-on-all.osm
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="1"/>
+  <node id="11" version="2" lat="2" lon="2"/>
+  <node id="12" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
+  <node id="14" version="1" lat="5" lon="1"/>
+  <way id="20" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="2">
+    <nd ref="12"/>
+    <nd ref="14"/>
+    <tag k="xyz" v="new"/>
+  </way>
+  <relation id="30" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+</osm>

--- a/test/apply-changes/output-version-applied-on-version+timestamp-low.osm
+++ b/test/apply-changes/output-version-applied-on-version+timestamp-low.osm
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="1" version="3" lat="50.001" lon="10">
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="School"/>
+  </node>
+  <node id="2" version="2" timestamp="2017-01-03T00:00:00Z" lat="50" lon="10.01"/>
+  <node id="4" version="1" lat="50" lon="10.02"/>
+  <way id="1" version="2">
+    <nd ref="1" lat="50.001" lon="10"/>
+    <nd ref="2" lat="50" lon="10.01"/>
+    <nd ref="4" lat="50" lon="10.02"/>
+    <tag k="highway" v="residential"/>
+  </way>
+  <way id="2" version="1" timestamp="2017-01-03T00:00:00Z">
+    <nd ref="1" lat="50.001" lon="10"/>
+    <nd ref="2" lat="50" lon="10.01"/>
+    <tag k="highway" v="path"/>
+  </way>
+  <relation id="1" version="1" timestamp="2017-01-03T00:00:00Z">
+    <member type="node" ref="1" role="stop"/>
+    <member type="way" ref="1" role=""/>
+    <tag k="type" v="route"/>
+    <tag k="route" v="bus"/>
+  </relation>
+</osm>

--- a/test/apply-changes/output-version-applied-on-version+timestamp.osm
+++ b/test/apply-changes/output-version-applied-on-version+timestamp.osm
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="1" version="3" lat="50.001" lon="10">
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="School"/>
+  </node>
+  <node id="2" version="2" timestamp="2017-01-03T00:00:00Z" lat="50" lon="10.01"/>
+  <node id="4" version="1" lat="50" lon="10.02"/>
+  <way id="1" version="2">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="4"/>
+    <tag k="highway" v="residential"/>
+  </way>
+  <way id="2" version="1" timestamp="2017-01-03T00:00:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <tag k="highway" v="path"/>
+  </way>
+  <relation id="1" version="1" timestamp="2017-01-03T00:00:00Z">
+    <member type="node" ref="1" role="stop"/>
+    <member type="way" ref="1" role=""/>
+    <tag k="type" v="route"/>
+    <tag k="route" v="bus"/>
+  </relation>
+</osm>


### PR DESCRIPTION
This makes the application of diffs work if the diff has only version fields but the input file has timestamp and version fields (and maybe even more).