### PR TITLE
Add new option --ignore-timestamps to osmium derive-changes

### DIFF
--- a/man/osmium-derive-changes.md
+++ b/man/osmium-derive-changes.md
@@ -61,6 +61,14 @@ STDOUT.
 :   Update timestamp of deleted objects to the current time. This is the same
     behaviour as Osmosis.
 
+--ignore-timestamps
+:   Do not use the timestamp to compare two objects. If the objects in one
+    input file have timestamps but the objects in the other input file do not
+    have timestamps, all objects will be written to the input file twice
+    because their metadata changed (fields being added or dropped) although
+    their coordinates, tags or members did not change. This option prevents the
+    diff become huge under these circumstances.
+
 
 @MAN_COMMON_OPTIONS@
 @MAN_PROGRESS_OPTIONS@

--- a/src/command_derive_changes.hpp
+++ b/src/command_derive_changes.hpp
@@ -47,6 +47,10 @@ class CommandDeriveChanges : public Command, public with_multiple_osm_inputs, pu
     bool m_keep_details = false;
     bool m_update_timestamp = false;
     bool m_increment_version = false;
+    bool m_ignore_metadata_changes = false;
+
+    template <typename TComp>
+    void derive_changes();
 
 public:
 

--- a/test/derive-changes/CMakeLists.txt
+++ b/test/derive-changes/CMakeLists.txt
@@ -14,5 +14,17 @@ check_derive_changes(normal       ""                    input1.osm input2.osm ou
 check_derive_changes(keep_details "--keep-details"      input1.osm input2.osm output-keep-details.osc)
 check_derive_changes(incr_version "--increment-version" input1.osm input2.osm output-incr-version.osc)
 
+# Tests with input file which don't have the same amount of metadata fields:
+# File 1 has all metadata fields, file 2 has only version fields.
+check_derive_changes(new_file_only_versions "--ignore-timestamps" input1.osm input2-only-versions.osm output-2-only-version.osc)
+
+# File 1 has only version and timestamp fields, file 2 has only version fields.
+check_derive_changes(version_timestamp_with_version "--ignore-timestamps" input1-only-version-timestamp.osm input2-only-versions.osm output-2-only-version-timestamp.osc)
+
+# File 1 has only version fields, file 2 has version and timestamp fields.
+check_derive_changes(version_with_version_timestamp "--ignore-timestamps" input1-only-version.osm input2-only-version-timestamp.osm output-2-version-with-version-timestamp.osc)
+
+# File 1 has only version fields, file 2 has all metadata fields.
+check_derive_changes(version_with_all "--ignore-timestamps" input1-only-version.osm input2-all-with-relation.osm output-2-version-with-all.osc)
 
 #-----------------------------------------------------------------------------

--- a/test/derive-changes/input1-only-version-timestamp.osm
+++ b/test/derive-changes/input1-only-version-timestamp.osm
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" upload="false" generator="testdata">
+  <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" lat="1" lon="1"/>
+  <node id="11" version="1" timestamp="2015-01-01T01:00:00Z" lat="2" lon="1"/>
+  <node id="12" version="1" timestamp="2015-01-01T01:00:00Z" lat="3" lon="1"/>
+  <node id="13" version="1" timestamp="2015-01-01T01:00:00Z" lat="4" lon="1">
+    <tag k="foo" v="bar"/>
+  </node>
+  <way id="20" version="1" timestamp="2015-01-01T01:00:00Z">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="1" timestamp="2015-01-01T01:00:00Z">
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1" timestamp="2015-01-01T01:00:00Z">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+</osm>

--- a/test/derive-changes/input1-only-version.osm
+++ b/test/derive-changes/input1-only-version.osm
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="osmium/1.7.1">
+  <node id="1" version="2" lat="50" lon="10">
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="School"/>
+  </node>
+  <node id="2" version="2" lat="50" lon="10.01"/>
+  <node id="3" version="1" lat="50" lon="10.02"/>
+  <way id="1" version="1">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <tag k="highway" v="residential"/>
+  </way>
+  <way id="2" version="1">
+    <nd ref="1"/>
+    <nd ref="3"/>
+    <tag k="highway" v="path"/>
+  </way>
+  <relation id="1" version="1">
+    <member type="node" ref="1" role="stop"/>
+    <member type="way" ref="1" role=""/>
+    <tag k="type" v="route"/>
+    <tag k="route" v="bus"/>
+  </relation>
+</osm>

--- a/test/derive-changes/input2-all-with-relation.osm
+++ b/test/derive-changes/input2-all-with-relation.osm
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6">
+  <node id="1" user="foo" uid="2" changeset="30" timestamp="2017-12-03T00:00:00Z" version="3" lat="50.001" lon="10.0">
+    <tag k="highway" v="bus_stop" />
+    <tag k="name" v="School" />
+  </node>
+  <node id="2" user="foo" uid="2" changeset="3" timestamp="2017-01-03T00:00:00Z" version="2" lat="50.0" lon="10.01"/>
+  <node id="4" user="foo" uid="2" changeset="3" timestamp="2017-12-03T00:00:00Z" version="1" lat="50.0" lon="10.02"/>
+  <way id="1" user="foo" uid="2" changeset="3" timestamp="2017-12-03T00:00:00Z" version="2">
+    <tag k="highway" v="residential" />
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="4"/>
+  </way>
+  <way id="2" user="foo" uid="2" changeset="3" timestamp="2017-01-03T00:00:00Z" version="1">
+    <tag k="highway" v="path" />
+    <nd ref="1"/>
+    <nd ref="2"/>
+  </way>
+  <relation id="1" user="foo" uid="2" changeset="3" timestamp="2017-01-03T00:00:00Z" version="1">
+    <tag k="type" v="route" />
+    <tag k="route" v="bus" />
+    <member type="node" ref="1" role="stop"/>
+    <member type="way" ref="1" role=""/>
+  </relation>
+</osm>

--- a/test/derive-changes/input2-only-version-timestamp.osm
+++ b/test/derive-changes/input2-only-version-timestamp.osm
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6">
+  <node id="1" timestamp="2017-12-03T00:00:00Z" version="3" lat="50.001" lon="10.0">
+    <tag k="highway" v="bus_stop" />
+    <tag k="name" v="School" />
+  </node>
+  <node id="2" timestamp="2017-01-03T00:00:00Z" version="2" lat="50.0" lon="10.01"/>
+  <node id="4" timestamp="2017-12-03T00:00:00Z" version="1" lat="50.0" lon="10.02"/>
+  <way id="1" timestamp="2017-12-03T00:00:00Z" version="2">
+    <tag k="highway" v="residential" />
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="4"/>
+  </way>
+  <way id="2" timestamp="2017-01-03T00:00:00Z" version="1">
+    <tag k="highway" v="path" />
+    <nd ref="1"/>
+    <nd ref="2"/>
+  </way>
+  <relation id="1" timestamp="2017-01-03T00:00:00Z" version="1">
+    <tag k="type" v="route" />
+    <tag k="route" v="bus" />
+    <member type="node" ref="1" role="stop"/>
+    <member type="way" ref="1" role=""/>
+  </relation>
+</osm>

--- a/test/derive-changes/input2-only-versions.osm
+++ b/test/derive-changes/input2-only-versions.osm
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" lat="1" lon="1"/>
+  <node id="11" version="2" lat="2" lon="2"/>
+  <node id="12" version="1" lat="3" lon="1"/>
+  <node id="14" version="1" lat="5" lon="1"/>
+  <way id="20" version="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="2">
+    <nd ref="12"/>
+    <nd ref="14"/>
+    <tag k="xyz" v="new"/>
+  </way>
+  <relation id="30" version="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+</osm>

--- a/test/derive-changes/output-2-only-version-timestamp.osc
+++ b/test/derive-changes/output-2-only-version-timestamp.osc
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osmChange version="0.6" generator="test">
+  <modify>
+    <node id="11" version="2" lat="2" lon="2"/>
+  </modify>
+  <delete>
+    <node id="13" version="1" timestamp="2015-01-01T01:00:00Z"/>
+  </delete>
+  <create>
+    <node id="14" version="1" lat="5" lon="1"/>
+  </create>
+  <modify>
+    <way id="21" version="2">
+      <nd ref="12"/>
+      <nd ref="14"/>
+      <tag k="xyz" v="new"/>
+    </way>
+  </modify>
+</osmChange>

--- a/test/derive-changes/output-2-only-version.osc
+++ b/test/derive-changes/output-2-only-version.osc
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osmChange version="0.6" generator="test">
+  <modify>
+    <node id="11" version="2" lat="2" lon="2"/>
+  </modify>
+  <delete>
+    <node id="13" version="1" timestamp="2015-01-01T01:00:00Z"/>
+  </delete>
+  <create>
+    <node id="14" version="1" lat="5" lon="1"/>
+  </create>
+  <modify>
+    <way id="21" version="2">
+      <nd ref="12"/>
+      <nd ref="14"/>
+      <tag k="xyz" v="new"/>
+    </way>
+  </modify>
+</osmChange>

--- a/test/derive-changes/output-2-version-with-all.osc
+++ b/test/derive-changes/output-2-version-with-all.osc
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osmChange version="0.6" generator="test">
+  <modify>
+    <node id="1" version="3" timestamp="2017-12-03T00:00:00Z" uid="2" user="foo" changeset="30" lat="50.001" lon="10">
+      <tag k="highway" v="bus_stop"/>
+      <tag k="name" v="School"/>
+    </node>
+  </modify>
+  <delete>
+    <node id="3" version="1"/>
+  </delete>
+  <create>
+    <node id="4" version="1" timestamp="2017-12-03T00:00:00Z" uid="2" user="foo" changeset="3" lat="50" lon="10.02"/>
+  </create>
+  <modify>
+    <way id="1" version="2" timestamp="2017-12-03T00:00:00Z" uid="2" user="foo" changeset="3">
+      <nd ref="1"/>
+      <nd ref="2"/>
+      <nd ref="4"/>
+      <tag k="highway" v="residential"/>
+    </way>
+  </modify>
+</osmChange>

--- a/test/derive-changes/output-2-version-with-version-timestamp.osc
+++ b/test/derive-changes/output-2-version-with-version-timestamp.osc
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osmChange version="0.6" generator="test">
+  <modify>
+    <node id="1" version="3" timestamp="2017-12-03T00:00:00Z" lat="50.001" lon="10">
+      <tag k="highway" v="bus_stop"/>
+      <tag k="name" v="School"/>
+    </node>
+  </modify>
+  <delete>
+    <node id="3" version="1"/>
+  </delete>
+  <create>
+    <node id="4" version="1" timestamp="2017-12-03T00:00:00Z" lat="50" lon="10.02"/>
+  </create>
+  <modify>
+    <way id="1" version="2" timestamp="2017-12-03T00:00:00Z">
+      <nd ref="1"/>
+      <nd ref="2"/>
+      <nd ref="4"/>
+      <tag k="highway" v="residential"/>
+    </way>
+  </modify>
+</osmChange>


### PR DESCRIPTION
`OSMObject::operator<` does is used by derive-changes to determine if two objects are equal. However, this operator does take the timestamp into account. If the timestamp is missing on one object, it will be the default (0) which leads to wrong and unexpected results.

Some users might prefer Osmium to produce a huge diff on the day, personal metadata is not being published by the OSMF any more to clean their own copies from personal information. On the other than, the diffs will become very huge (larger than the input file because of duplications and much larger if the input file was a PBF file).