### PR TITLE
Add metadata options to the extended output of fileinfo command

### DIFF
--- a/man/osmium-fileinfo.md
+++ b/man/osmium-fileinfo.md
@@ -23,7 +23,7 @@ Normally this command will output the data in human readable form. If the
 If the **-g**, **--get** option is used, only the value of the named variable
 will be printed.
 
-The output is split into three sections:
+The output is split into four sections:
 
 File
 :   This section shows the information available without opening the
@@ -47,6 +47,13 @@ Data
     id, and whether there were multiple versions of the same object in
     the file (history files and change files can have that). See the
     **osmium-sort**(1) man page for details of the expected ordering.
+
+Metadata
+:   This section shows which metadata attributes are used in the file.
+    It contains information which attributes are used by all objects in
+    the file and which are only used by some objects. This section is
+    only shown if the **--extended** option was used because the whole
+    file has to be read.
 
 This commands reads its input file only once, ie. it can read from STDIN.
 
@@ -100,9 +107,26 @@ The following variables are available:
     data.maxid.ways - INTEGER
     data.maxid.relations - INTEGER
     data.maxid.changesets - INTEGER
+    metadata.all_objects.version - BOOL (yes|no)
+    metadata.all_objects.timestamp - BOOL (yes|no)
+    metadata.all_objects.changeset - BOOL (yes|no)
+    metadata.all_objects.uid - BOOL (yes|no)
+    metadata.all_objects.user - BOOL (yes|no)
+    metadata.some_objects.version - BOOL (yes|no)
+    metadata.some_objects.timestamp - BOOL (yes|no)
+    metadata.some_objects.changeset - BOOL (yes|no)
+    metadata.some_objects.uid - BOOL (yes|no)
+    metadata.some_objects.user - BOOL (yes|no)
 
 All timestamps are in the usual OSM ISO format `yy-mm-ddThh::mm::ssZ`. Boxes
 are in the format `(xmin, ymin, xmax, ymax)`.
+
+There are two variables for each metadata field. The `metadata.all_objects.*`
+variables are true if all objects in the file have the attribute. The
+`metadata.some_objects.*` variables are true if at least one object in the file
+has the attribute. Please note that objects last modified by anonymous users
+(until 2007) do not have `user` and `uid` attributes and can lead to wrong
+results.
 
 
 # DIAGNOSTICS

--- a/src/command_fileinfo.cpp
+++ b/src/command_fileinfo.cpp
@@ -26,13 +26,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <osmium/handler.hpp>
 #include <osmium/io/file.hpp>
-#include <osmium/osm/metadata_options.hpp>
 #include <osmium/io/header.hpp>
 #include <osmium/io/reader.hpp>
 #include <osmium/osm.hpp>
 #include <osmium/osm/box.hpp>
 #include <osmium/osm/crc.hpp>
 #include <osmium/osm/object_comparisons.hpp>
+#include <osmium/osm/metadata_options.hpp>
 #include <osmium/util/file.hpp>
 #include <osmium/util/minmax.hpp>
 #include <osmium/util/progress_bar.hpp>
@@ -77,8 +77,8 @@ struct InfoHandler : public osmium::handler::Handler {
     osmium::max_op<osmium::object_id_type> largest_node_id{0};
     osmium::max_op<osmium::object_id_type> largest_way_id{0};
     osmium::max_op<osmium::object_id_type> largest_relation_id{0};
-    osmium::metadata_options minimum_metadata{"all"};
-    osmium::metadata_options maximum_metadata{"none"};
+    osmium::metadata_options metadata_all_objects{"all"};
+    osmium::metadata_options metadata_some_objects{"none"};
 
     osmium::min_op<osmium::Timestamp> first_timestamp;
     osmium::max_op<osmium::Timestamp> last_timestamp;
@@ -111,8 +111,8 @@ struct InfoHandler : public osmium::handler::Handler {
         first_timestamp.update(object.timestamp());
         last_timestamp.update(object.timestamp());
 
-        minimum_metadata &= osmium::detect_available_metadata(object);
-        maximum_metadata |= osmium::detect_available_metadata(object);
+        metadata_all_objects &= osmium::detect_available_metadata(object);
+        metadata_some_objects |= osmium::detect_available_metadata(object);
 
         if (last_type == object.type()) {
             if (last_id == object.id()) {
@@ -240,8 +240,8 @@ public:
         std::cout << "  Largest way ID: "       << info_handler.largest_way_id()       << "\n";
         std::cout << "  Largest relation ID: "  << info_handler.largest_relation_id()  << "\n";
 
-        std::cout << "  All objects have following metadata attributes: " << info_handler.minimum_metadata  << "\n";
-        std::cout << "  Some objects have following metadata attributes: " << info_handler.maximum_metadata  << "\n";
+        std::cout << "  All objects have following metadata attributes: " << info_handler.metadata_all_objects  << "\n";
+        std::cout << "  Some objects have following metadata attributes: " << info_handler.metadata_some_objects  << "\n";
     }
 
 }; // class HumanReadableOutput
@@ -379,28 +379,28 @@ public:
         m_writer.String("all_objects");
         m_writer.StartObject();
         m_writer.String("version");
-        m_writer.Bool(info_handler.minimum_metadata.version());
+        m_writer.Bool(info_handler.metadata_all_objects.version());
         m_writer.String("timestamp");
-        m_writer.Bool(info_handler.minimum_metadata.timestamp());
+        m_writer.Bool(info_handler.metadata_all_objects.timestamp());
         m_writer.String("changeset");
-        m_writer.Bool(info_handler.minimum_metadata.changeset());
+        m_writer.Bool(info_handler.metadata_all_objects.changeset());
         m_writer.String("user");
-        m_writer.Bool(info_handler.minimum_metadata.user());
+        m_writer.Bool(info_handler.metadata_all_objects.user());
         m_writer.String("uid");
-        m_writer.Bool(info_handler.minimum_metadata.uid());
+        m_writer.Bool(info_handler.metadata_all_objects.uid());
         m_writer.EndObject();
         m_writer.String("some_objects");
         m_writer.StartObject();
         m_writer.String("version");
-        m_writer.Bool(info_handler.maximum_metadata.version());
+        m_writer.Bool(info_handler.metadata_some_objects.version());
         m_writer.String("timestamp");
-        m_writer.Bool(info_handler.maximum_metadata.timestamp());
+        m_writer.Bool(info_handler.metadata_some_objects.timestamp());
         m_writer.String("changeset");
-        m_writer.Bool(info_handler.maximum_metadata.changeset());
+        m_writer.Bool(info_handler.metadata_some_objects.changeset());
         m_writer.String("user");
-        m_writer.Bool(info_handler.maximum_metadata.user());
+        m_writer.Bool(info_handler.metadata_some_objects.user());
         m_writer.String("uid");
-        m_writer.Bool(info_handler.maximum_metadata.uid());
+        m_writer.Bool(info_handler.metadata_some_objects.uid());
         m_writer.EndObject();
         m_writer.EndObject();
 
@@ -520,34 +520,34 @@ public:
             std::cout << info_handler.largest_relation_id() << "\n";
         }
         if (m_get_value == "metadata.all_objects.version") {
-            std::cout << (info_handler.minimum_metadata.version() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_all_objects.version() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.all_objects.timestamp") {
-            std::cout << (info_handler.minimum_metadata.timestamp() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_all_objects.timestamp() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.all_objects.changeset") {
-            std::cout << (info_handler.minimum_metadata.changeset() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_all_objects.changeset() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.all_objects.uid") {
-            std::cout << (info_handler.minimum_metadata.uid() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_all_objects.uid() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.all_objects.user") {
-            std::cout << (info_handler.minimum_metadata.user() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_all_objects.user() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.some_objects.version") {
-            std::cout << (info_handler.maximum_metadata.version() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_some_objects.version() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.some_objects.timestamp") {
-            std::cout << (info_handler.maximum_metadata.timestamp() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_some_objects.timestamp() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.some_objects.changeset") {
-            std::cout << (info_handler.maximum_metadata.changeset() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_some_objects.changeset() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.some_objects.uid") {
-            std::cout << (info_handler.maximum_metadata.uid() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_some_objects.uid() ? "yes\n" : "no\n");
         }
         if (m_get_value == "metadata.some_objects.user") {
-            std::cout << (info_handler.maximum_metadata.user() ? "yes\n" : "no\n");
+            std::cout << (info_handler.metadata_some_objects.user() ? "yes\n" : "no\n");
         }
     }
 

--- a/src/command_fileinfo.cpp
+++ b/src/command_fileinfo.cpp
@@ -519,11 +519,35 @@ public:
         if (m_get_value == "data.maxid.relations") {
             std::cout << info_handler.largest_relation_id() << "\n";
         }
-        if (m_get_value == "metadata.all_objects") {
-            std::cout << info_handler.minimum_metadata << "\n";
+        if (m_get_value == "metadata.all_objects.version") {
+            std::cout << (info_handler.minimum_metadata.version() ? "yes\n" : "no\n");
         }
-        if (m_get_value == "metadata.some_objects") {
-            std::cout << info_handler.maximum_metadata << "\n";
+        if (m_get_value == "metadata.all_objects.timestamp") {
+            std::cout << (info_handler.minimum_metadata.timestamp() ? "yes\n" : "no\n");
+        }
+        if (m_get_value == "metadata.all_objects.changeset") {
+            std::cout << (info_handler.minimum_metadata.changeset() ? "yes\n" : "no\n");
+        }
+        if (m_get_value == "metadata.all_objects.uid") {
+            std::cout << (info_handler.minimum_metadata.uid() ? "yes\n" : "no\n");
+        }
+        if (m_get_value == "metadata.all_objects.user") {
+            std::cout << (info_handler.minimum_metadata.user() ? "yes\n" : "no\n");
+        }
+        if (m_get_value == "metadata.some_objects.version") {
+            std::cout << (info_handler.maximum_metadata.version() ? "yes\n" : "no\n");
+        }
+        if (m_get_value == "metadata.some_objects.timestamp") {
+            std::cout << (info_handler.maximum_metadata.timestamp() ? "yes\n" : "no\n");
+        }
+        if (m_get_value == "metadata.some_objects.changeset") {
+            std::cout << (info_handler.maximum_metadata.changeset() ? "yes\n" : "no\n");
+        }
+        if (m_get_value == "metadata.some_objects.uid") {
+            std::cout << (info_handler.maximum_metadata.uid() ? "yes\n" : "no\n");
+        }
+        if (m_get_value == "metadata.some_objects.user") {
+            std::cout << (info_handler.maximum_metadata.user() ? "yes\n" : "no\n");
         }
     }
 
@@ -600,8 +624,16 @@ bool CommandFileinfo::setup(const std::vector<std::string>& arguments) {
         "data.maxid.ways",
         "data.maxid.relations",
         "data.maxid.changesets",
-        "metadata.all_objects",
-        "metadata.some_objects"
+        "metadata.all_objects.version",
+        "metadata.all_objects.timestamp",
+        "metadata.all_objects.changeset",
+        "metadata.all_objects.uid",
+        "metadata.all_objects.user",
+        "metadata.some_objects.version",
+        "metadata.some_objects.timestamp",
+        "metadata.some_objects.changeset",
+        "metadata.some_objects.uid",
+        "metadata.some_objects.user"
     };
 
     if (vm.count("show-variables")) {

--- a/test/fileinfo/CMakeLists.txt
+++ b/test/fileinfo/CMakeLists.txt
@@ -23,5 +23,17 @@ set_tests_properties(fileinfo-g-unknown-option PROPERTIES PASS_REGULAR_EXPRESSIO
 add_test(NAME fileinfo-g-fail COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi1.osm -g foobar)
 set_tests_properties(fileinfo-g-fail PROPERTIES WILL_FAIL true)
 
+# Test the metadata properties
+add_test(NAME fileinfo-metadata-min-mixed-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g data.metadata.minimum)
+set_tests_properties(fileinfo-metadata-min-mixed-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
+
+add_test(NAME fileinfo-metadata-max-mixed-all COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g data.metadata.maximum)
+set_tests_properties(fileinfo-metadata-max-mixed-all PROPERTIES PASS_REGULAR_EXPRESSION "^all\n$")
+
+add_test(NAME fileinfo-metadata-min-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g data.metadata.minimum)
+set_tests_properties(fileinfo-metadata-min-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
+
+add_test(NAME fileinfo-metadata-max-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g data.metadata.maximum)
+set_tests_properties(fileinfo-metadata-max-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
 
 #-----------------------------------------------------------------------------

--- a/test/fileinfo/CMakeLists.txt
+++ b/test/fileinfo/CMakeLists.txt
@@ -24,16 +24,16 @@ add_test(NAME fileinfo-g-fail COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/f
 set_tests_properties(fileinfo-g-fail PROPERTIES WILL_FAIL true)
 
 # Test the metadata properties
-add_test(NAME fileinfo-metadata-min-mixed-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g data.metadata.minimum)
+add_test(NAME fileinfo-metadata-min-mixed-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.all_objects)
 set_tests_properties(fileinfo-metadata-min-mixed-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
 
-add_test(NAME fileinfo-metadata-max-mixed-all COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g data.metadata.maximum)
+add_test(NAME fileinfo-metadata-max-mixed-all COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.some_objects)
 set_tests_properties(fileinfo-metadata-max-mixed-all PROPERTIES PASS_REGULAR_EXPRESSION "^all\n$")
 
-add_test(NAME fileinfo-metadata-min-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g data.metadata.minimum)
+add_test(NAME fileinfo-metadata-min-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.all_objects)
 set_tests_properties(fileinfo-metadata-min-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
 
-add_test(NAME fileinfo-metadata-max-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g data.metadata.maximum)
+add_test(NAME fileinfo-metadata-max-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.some_objects)
 set_tests_properties(fileinfo-metadata-max-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
 
 #-----------------------------------------------------------------------------

--- a/test/fileinfo/CMakeLists.txt
+++ b/test/fileinfo/CMakeLists.txt
@@ -23,17 +23,99 @@ set_tests_properties(fileinfo-g-unknown-option PROPERTIES PASS_REGULAR_EXPRESSIO
 add_test(NAME fileinfo-g-fail COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi1.osm -g foobar)
 set_tests_properties(fileinfo-g-fail PROPERTIES WILL_FAIL true)
 
+
+#-----------------------------------------------------------------------------
 # Test the metadata properties
-add_test(NAME fileinfo-metadata-min-mixed-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.all_objects)
-set_tests_properties(fileinfo-metadata-min-mixed-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
+#-----------------------------------------------------------------------------
 
-add_test(NAME fileinfo-metadata-max-mixed-all COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.some_objects)
-set_tests_properties(fileinfo-metadata-max-mixed-all PROPERTIES PASS_REGULAR_EXPRESSION "^all\n$")
+# The input file has objects with only version+timestamp and objects with all metadata attributes.
+# searching for metadata.all_objects.version
+add_test(NAME fileinfo-metadata-mixed-all-version COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.all_objects.version)
+set_tests_properties(fileinfo-metadata-mixed-all-version PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
 
-add_test(NAME fileinfo-metadata-min-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.all_objects)
-set_tests_properties(fileinfo-metadata-min-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
+# The input file has objects with only version+timestamp and objects with all metadata attributes.
+# searching for metadata.all_objects.timestamp
+add_test(NAME fileinfo-metadata-mixed-all-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.all_objects.timestamp)
+set_tests_properties(fileinfo-metadata-mixed-all-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
 
-add_test(NAME fileinfo-metadata-max-version-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.some_objects)
-set_tests_properties(fileinfo-metadata-max-version-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^version\\+timestamp\n$")
+# The input file has objects with only version+timestamp and objects with all metadata attributes.
+# searching for metadata.all_objects.changeset
+add_test(NAME fileinfo-metadata-mixed-all-changeset COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.all_objects.changeset)
+set_tests_properties(fileinfo-metadata-mixed-all-changeset PROPERTIES PASS_REGULAR_EXPRESSION "^no\n$")
+
+# The input file has objects with only version+timestamp and objects with all metadata attributes.
+# searching for metadata.some_objects.version
+add_test(NAME fileinfo-metadata-mixed-some-version COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.some_objects.version)
+set_tests_properties(fileinfo-metadata-mixed-some-version PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file has objects with only version+timestamp and objects with all metadata attributes.
+# searching for metadata.some_objects.timestamp
+add_test(NAME fileinfo-metadata-mixed-some-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.some_objects.timestamp)
+set_tests_properties(fileinfo-metadata-mixed-some-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file has objects with only version+timestamp and objects with all metadata attributes.
+# searching for metadata.some_objects.changeset
+add_test(NAME fileinfo-metadata-mixed-some-changeset COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.some_objects.changeset)
+set_tests_properties(fileinfo-metadata-mixed-some-changeset PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file has objects with only version+timestamp and objects with all metadata attributes.
+# searching for metadata.some_objects.uid
+add_test(NAME fileinfo-metadata-mixed-some-uid COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.some_objects.uid)
+set_tests_properties(fileinfo-metadata-mixed-some-uid PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file has objects with only version+timestamp and objects with all metadata attributes.
+# searching for metadata.some_objects.user
+add_test(NAME fileinfo-metadata-mixed-some-user COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi2.osm -e -g metadata.some_objects.user)
+set_tests_properties(fileinfo-metadata-mixed-some-user PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.all_objects.version
+add_test(NAME fileinfo-metadata-homogenous-all-version COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.all_objects.version)
+set_tests_properties(fileinfo-metadata-homogenous-all-version PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.all_objects.timestamp
+add_test(NAME fileinfo-metadata-homogenous-all-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.all_objects.timestamp)
+set_tests_properties(fileinfo-metadata-homogenous-all-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.all_objects.changeset
+add_test(NAME fileinfo-metadata-homogenous-all-changeset COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.all_objects.changeset)
+set_tests_properties(fileinfo-metadata-homogenous-all-changeset PROPERTIES PASS_REGULAR_EXPRESSION "^no\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.all_objects.uid
+add_test(NAME fileinfo-metadata-homogenous-all-uid COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.all_objects.uid)
+set_tests_properties(fileinfo-metadata-homogenous-all-uid PROPERTIES PASS_REGULAR_EXPRESSION "^no\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.all_objects.user
+add_test(NAME fileinfo-metadata-homogenous-all-user COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.all_objects.user)
+set_tests_properties(fileinfo-metadata-homogenous-all-user PROPERTIES PASS_REGULAR_EXPRESSION "^no\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.some_objects.version
+add_test(NAME fileinfo-metadata-homogenous-some-version COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.some_objects.version)
+set_tests_properties(fileinfo-metadata-homogenous-some-version PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.some_objects.timestamp
+add_test(NAME fileinfo-metadata-homogenous-some-timestamp COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.some_objects.timestamp)
+set_tests_properties(fileinfo-metadata-homogenous-some-timestamp PROPERTIES PASS_REGULAR_EXPRESSION "^yes\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.some_objects.changeset
+add_test(NAME fileinfo-metadata-homogenous-some-changeset COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.some_objects.changeset)
+set_tests_properties(fileinfo-metadata-homogenous-some-changeset PROPERTIES PASS_REGULAR_EXPRESSION "^no\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.some_objects.uid
+add_test(NAME fileinfo-metadata-homogenous-some-uid COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.some_objects.uid)
+set_tests_properties(fileinfo-metadata-homogenous-some-uid PROPERTIES PASS_REGULAR_EXPRESSION "^no\n$")
+
+# The input file contains only objects with version+timestamp.
+# searching for metadata.some_objects.user
+add_test(NAME fileinfo-metadata-homogenous-some-user COMMAND osmium fileinfo ${CMAKE_SOURCE_DIR}/test/fileinfo/fi3.osm -e -g metadata.some_objects.user)
+set_tests_properties(fileinfo-metadata-homogenous-some-user PROPERTIES PASS_REGULAR_EXPRESSION "^no\n$")
 
 #-----------------------------------------------------------------------------

--- a/test/fileinfo/fi1-result.txt
+++ b/test/fileinfo/fi1-result.txt
@@ -25,5 +25,5 @@ Data:
   Largest node ID: 4
   Largest way ID: 0
   Largest relation ID: 0
-  Minimum amount of metadata: all
-  Maximum amount of metadata: all
+  All objects have following metadata attributes: all
+  Some objects have following metadata attributes: all

--- a/test/fileinfo/fi1-result.txt
+++ b/test/fileinfo/fi1-result.txt
@@ -25,3 +25,5 @@ Data:
   Largest node ID: 4
   Largest way ID: 0
   Largest relation ID: 0
+  Minimum amount of metadata: all
+  Maximum amount of metadata: all

--- a/test/fileinfo/fi2.osm
+++ b/test/fileinfo/fi2.osm
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="testdata" upload="false">
+  <node id="1" version="1" timestamp="2015-01-01T01:00:00Z" lat="1" lon="1"/>
+  <node id="2" version="1" timestamp="2015-01-01T02:00:00Z" lat="2" lon="1"/>
+  <node id="4" version="1" timestamp="2015-01-01T04:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
+</osm>

--- a/test/fileinfo/fi3.osm
+++ b/test/fileinfo/fi3.osm
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="testdata" upload="false">
+  <node id="1" version="1" timestamp="2015-01-01T01:00:00Z" lat="1" lon="1"/>
+  <node id="2" version="1" timestamp="2015-01-01T02:00:00Z" lat="2" lon="1"/>
+  <node id="4" version="1" timestamp="2015-01-01T04:00:00Z" lat="3" lon="1"/>
+</osm>


### PR DESCRIPTION
The fileinfo command now writes to the output which amount of metadata is available in the input file.

Unfortunately, the results cannot be fully accurate because anonymous edits (they are in full-history dumps and I doubt that some haven't be modified yet, so they might also appear in the planet) don't have `user` and `uid` fields.

EDIT: This requires https://github.com/osmcode/libosmium/pull/248 to be merged. That's why Travis builds will fail.