### PR TITLE
Merge command: ignore timestamps in two-file mode

### DIFF
--- a/src/command_merge.cpp
+++ b/src/command_merge.cpp
@@ -32,6 +32,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <osmium/memory/buffer.hpp>
 #include <osmium/osm/entity_bits.hpp>
 #include <osmium/osm/object.hpp>
+#include <osmium/osm/object_comparisons.hpp>
 #include <osmium/util/verbose_output.hpp>
 
 #include <boost/program_options.hpp>
@@ -193,7 +194,8 @@ bool CommandMerge::run() {
 
         std::set_union(in1.cbegin(), in1.cend(),
                        in2.cbegin(), in2.cend(),
-                       out);
+                       out,
+                       osmium::object_order_type_id_version_without_timestamp());
     } else {
         // Three or more files to merge
         m_vout << "Merging " << m_input_files.size() << " input files to output file...\n";

--- a/test/merge/CMakeLists.txt
+++ b/test/merge/CMakeLists.txt
@@ -32,4 +32,25 @@ check_merge2(i2r-2-only-version input2-only-version.osm input1.osm output2-2-onl
 check_merge2(i2f-1-only-version input1-only-version.osm input2.osm output2-1-only-version.osm)
 check_merge2(i2r-1-only-version input2.osm input1-only-version.osm output2-1-only-version.osm)
 
+# If two input files do not have timestamp attributes …
+check_merge3(i3f-1-only-version input1-only-version.osm input2.osm input3.osm output3-1-only-version.osm)
+check_merge3(i3r-1-only-version input3.osm input2.osm input1-only-version.osm output3-1-only-version.osm)
+check_merge3(i3m-1-only-version input2.osm input3.osm input1-only-version.osm output3-1-only-version.osm)
+
+check_merge3(i3f-2-only-version input1.osm input2-only-version.osm input3.osm output3-2-only-version.osm)
+check_merge3(i3r-2-only-version input3.osm input2-only-version.osm input1.osm output3-2-only-version.osm)
+check_merge3(i3m-2-only-version input3.osm input1.osm input2-only-version.osm output3-2-only-version.osm)
+
+check_merge3(i3f-12-only-version input1-only-version.osm input2-only-version.osm input3.osm output3-12-only-version.osm)
+check_merge3(i3r-12-only-version input3.osm input2-only-version.osm input1-only-version.osm output3-12-only-version.osm)
+check_merge3(i3m-12-only-version input3.osm input1-only-version.osm input2-only-version.osm output3-12-only-version.osm)
+
+check_merge3(i3f-13-only-version input1-only-version.osm input2.osm input3-only-version.osm output3-13-only-version.osm)
+check_merge3(i3r-13-only-version input3-only-version.osm input2.osm input1-only-version.osm output3-13-only-version.osm)
+check_merge3(i3m-13-only-version input2.osm input1-only-version.osm input3-only-version.osm output3-13-only-version.osm)
+
+check_merge3(i3f-23-only-version input1.osm input2-only-version.osm input3-only-version.osm output3-23-only-version.osm)
+check_merge3(i3r-23-only-version input3-only-version.osm input2-only-version.osm input1.osm output3-23-only-version.osm)
+check_merge3(i3m-23-only-version input2-only-version.osm input3-only-version.osm input1.osm output3-23-only-version.osm)
+
 #-----------------------------------------------------------------------------

--- a/test/merge/CMakeLists.txt
+++ b/test/merge/CMakeLists.txt
@@ -26,5 +26,10 @@ check_merge2(i2f input1.osm input2.osm output2.osm)
 check_merge2(i2r input2.osm input1.osm output2.osm)
 check_merge3(i3f input1.osm input2.osm input3.osm output3.osm)
 
+# If one input file does not have timestamp attributes …
+check_merge2(i2f-2-only-version input1.osm input2-only-version.osm output2-2-only-version.osm)
+check_merge2(i2r-2-only-version input2-only-version.osm input1.osm output2-2-only-version.osm)
+check_merge2(i2f-1-only-version input1-only-version.osm input2.osm output2-1-only-version.osm)
+check_merge2(i2r-1-only-version input2.osm input1-only-version.osm output2-1-only-version.osm)
 
 #-----------------------------------------------------------------------------

--- a/test/merge/input1-only-version.osm
+++ b/test/merge/input1-only-version.osm
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" upload="false" generator="testdata">
+  <node id="10" version="1" lat="1" lon="1"/>
+  <node id="11" version="1" lat="2" lon="1"/>
+  <node id="13" version="1" lat="4" lon="1"/>
+  <node id="14" version="1" lat="5" lon="1"/>
+  <node id="16" version="2" lat="8" lon="1"/>
+  <way id="20" version="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="13"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="24" version="1">
+    <nd ref="14"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="31" version="1">
+    <member type="node" ref="13" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/input2-only-version.osm
+++ b/test/merge/input2-only-version.osm
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" upload="false" generator="testdata">
+  <node id="10" version="1" lat="1" lon="1"/>
+  <node id="12" version="1" lat="3" lon="1"/>
+  <node id="15" version="1" lat="6" lon="1"/>
+  <node id="16" version="1" lat="7" lon="1"/>
+  <way id="21" version="1">
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="22" version="1">
+    <nd ref="15"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="21" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/input3-only-version.osm
+++ b/test/merge/input3-only-version.osm
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" upload="false" generator="testdata">
+  <node id="17" version="1" lat="8" lon="1"/>
+  <node id="18" version="1" lat="9" lon="1"/>
+  <node id="19" version="1" lat="10" lon="1"/>
+  <way id="23" version="1">
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="18"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <relation id="33" version="1">
+    <member type="node" ref="17" role="m1"/>
+    <member type="way" ref="23" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/output2-1-only-version.osm
+++ b/test/merge/output2-1-only-version.osm
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="1"/>
+  <node id="11" version="1" lat="2" lon="1"/>
+  <node id="12" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
+  <node id="13" version="1" lat="4" lon="1"/>
+  <node id="14" version="1" lat="5" lon="1"/>
+  <node id="15" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="6" lon="1"/>
+  <node id="16" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="7" lon="1"/>
+  <node id="16" version="2" lat="8" lon="1"/>
+  <way id="20" version="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="13"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="22" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="15"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <way id="24" version="1">
+    <nd ref="14"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="21" role="m2"/>
+  </relation>
+  <relation id="31" version="1">
+    <member type="node" ref="13" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/output2-2-only-version.osm
+++ b/test/merge/output2-2-only-version.osm
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="1"/>
+  <node id="11" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="2" lon="1"/>
+  <node id="12" version="1" lat="3" lon="1"/>
+  <node id="13" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="4" lon="1"/>
+  <node id="14" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="5" lon="1"/>
+  <node id="15" version="1" lat="6" lon="1"/>
+  <node id="16" version="1" lat="7" lon="1"/>
+  <node id="16" version="2" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="8" lon="1"/>
+  <way id="20" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="13"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="1">
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="22" version="1">
+    <nd ref="15"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <way id="24" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="14"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="21" role="m2"/>
+  </relation>
+  <relation id="31" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="13" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/output3-1-only-version.osm
+++ b/test/merge/output3-1-only-version.osm
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="1"/>
+  <node id="11" version="1" lat="2" lon="1"/>
+  <node id="12" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
+  <node id="13" version="1" lat="4" lon="1"/>
+  <node id="14" version="1" lat="5" lon="1"/>
+  <node id="15" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="6" lon="1"/>
+  <node id="16" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="7" lon="1"/>
+  <node id="16" version="2" lat="8" lon="1"/>
+  <node id="17" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="8" lon="1"/>
+  <node id="18" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="9" lon="1"/>
+  <node id="19" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="10" lon="1"/>
+  <way id="20" version="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="13"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="22" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="15"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <way id="23" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="18"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="24" version="1">
+    <nd ref="14"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="21" role="m2"/>
+  </relation>
+  <relation id="31" version="1">
+    <member type="node" ref="13" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+  <relation id="33" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="17" role="m1"/>
+    <member type="way" ref="23" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/output3-12-only-version.osm
+++ b/test/merge/output3-12-only-version.osm
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" lat="1" lon="1"/>
+  <node id="11" version="1" lat="2" lon="1"/>
+  <node id="12" version="1" lat="3" lon="1"/>
+  <node id="13" version="1" lat="4" lon="1"/>
+  <node id="14" version="1" lat="5" lon="1"/>
+  <node id="15" version="1" lat="6" lon="1"/>
+  <node id="16" version="1" lat="7" lon="1"/>
+  <node id="16" version="2" lat="8" lon="1"/>
+  <node id="17" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="8" lon="1"/>
+  <node id="18" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="9" lon="1"/>
+  <node id="19" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="10" lon="1"/>
+  <way id="20" version="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="13"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="1">
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="22" version="1">
+    <nd ref="15"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <way id="23" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="18"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="24" version="1">
+    <nd ref="14"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="21" role="m2"/>
+  </relation>
+  <relation id="31" version="1">
+    <member type="node" ref="13" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+  <relation id="33" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="17" role="m1"/>
+    <member type="way" ref="23" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/output3-13-only-version.osm
+++ b/test/merge/output3-13-only-version.osm
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="1"/>
+  <node id="11" version="1" lat="2" lon="1"/>
+  <node id="12" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
+  <node id="13" version="1" lat="4" lon="1"/>
+  <node id="14" version="1" lat="5" lon="1"/>
+  <node id="15" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="6" lon="1"/>
+  <node id="16" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="7" lon="1"/>
+  <node id="16" version="2" lat="8" lon="1"/>
+  <node id="17" version="1" lat="8" lon="1"/>
+  <node id="18" version="1" lat="9" lon="1"/>
+  <node id="19" version="1" lat="10" lon="1"/>
+  <way id="20" version="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="13"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="22" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="15"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <way id="23" version="1">
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="18"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="24" version="1">
+    <nd ref="14"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="21" role="m2"/>
+  </relation>
+  <relation id="31" version="1">
+    <member type="node" ref="13" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+  <relation id="33" version="1">
+    <member type="node" ref="17" role="m1"/>
+    <member type="way" ref="23" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/output3-2-only-version.osm
+++ b/test/merge/output3-2-only-version.osm
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="1"/>
+  <node id="11" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="2" lon="1"/>
+  <node id="12" version="1" lat="3" lon="1"/>
+  <node id="13" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="4" lon="1"/>
+  <node id="14" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="5" lon="1"/>
+  <node id="15" version="1" lat="6" lon="1"/>
+  <node id="16" version="1" lat="7" lon="1"/>
+  <node id="16" version="2" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="8" lon="1"/>
+  <node id="17" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="8" lon="1"/>
+  <node id="18" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="9" lon="1"/>
+  <node id="19" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="10" lon="1"/>
+  <way id="20" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="13"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="1">
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="22" version="1">
+    <nd ref="15"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <way id="23" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="18"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="24" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="14"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="21" role="m2"/>
+  </relation>
+  <relation id="31" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="13" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+  <relation id="33" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="17" role="m1"/>
+    <member type="way" ref="23" role="m2"/>
+  </relation>
+</osm>

--- a/test/merge/output3-23-only-version.osm
+++ b/test/merge/output3-23-only-version.osm
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="1"/>
+  <node id="11" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="2" lon="1"/>
+  <node id="12" version="1" lat="3" lon="1"/>
+  <node id="13" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="4" lon="1"/>
+  <node id="14" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="5" lon="1"/>
+  <node id="15" version="1" lat="6" lon="1"/>
+  <node id="16" version="1" lat="7" lon="1"/>
+  <node id="16" version="2" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="8" lon="1"/>
+  <node id="17" version="1" lat="8" lon="1"/>
+  <node id="18" version="1" lat="9" lon="1"/>
+  <node id="19" version="1" lat="10" lon="1"/>
+  <way id="20" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="13"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="21" version="1">
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="22" version="1">
+    <nd ref="15"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <way id="23" version="1">
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="18"/>
+    <tag k="foo" v="bar"/>
+  </way>
+  <way id="24" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="14"/>
+    <nd ref="16"/>
+    <tag k="xyz" v="abc"/>
+  </way>
+  <relation id="30" version="1">
+    <member type="node" ref="12" role="m1"/>
+    <member type="way" ref="21" role="m2"/>
+  </relation>
+  <relation id="31" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="node" ref="13" role="m1"/>
+    <member type="way" ref="20" role="m2"/>
+  </relation>
+  <relation id="33" version="1">
+    <member type="node" ref="17" role="m1"/>
+    <member type="way" ref="23" role="m2"/>
+  </relation>
+</osm>


### PR DESCRIPTION
Changes:

* ignore the timestamp  in two-file mode (three-file mode did not need any changes)
* add unit tests for the change above
* add unit tests for the three-file mode if one or two files only have `version` attributes and no other metadata attributes