### PR TITLE
Add missing cd osmium-tool to Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Libosmium, Protozero, and Osmium, clone all of them into the same directory:
 
 Osmium uses CMake for its builds. On Linux and macOS you can build as follows:
 
+    cd osmium-tool
     mkdir build
     cd build
     cmake ..


### PR DESCRIPTION
If a user follows these commands one by one, he will create build/ at the same level as `osmium-tool/`, `libosmium/` and `protozero/`. That's wrong and `cmake ..` in `build/` will fail because build/ should be located in `osmium-tool`.

Thanks to user hfst at https://forum.openstreetmap.org/viewtopic.php?id=61908