### PR TITLE
Added artifacts for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,3 +31,20 @@ build_script:
   - cd c:\projects/osmium-tool
   - build-appveyor.bat
 
+after_build:
+  - cd c:\projects
+  - mkdir osmium-tool-bin
+  - set dllsuffix=""
+  - if "%config%"=="Debug" set dllsuffix="d"
+  - appveyor DownloadFile "https://raw.githubusercontent.com/libexpat/libexpat/master/expat/COPYING" -FileName osmium-tool-bin\COPYING-expat.txt
+  - appveyor DownloadFile "https://raw.githubusercontent.com/asimonov-im/bzip2/master/LICENSE" -FileName osmium-tool-bin\LICENSE-bzip2.txt
+  - copy /y C:\projects\osmium-tool\LICENSE.txt osmium-tool-bin
+  - copy /y C:\projects\osmium-tool\LICENSE-rapidjson.txt osmium-tool-bin
+  - copy /y C:\projects\osmium-tool\build\src\%config%\osmium.exe osmium-tool-bin
+  - copy /y C:\projects\expat.v140.2.2.5\build\native\bin\x64\%config%\libexpat%dllsuffix%.dll osmium-tool-bin
+  - copy /y C:\projects\bzip2.v140.1.0.6.9\build\native\bin\x64\MT-%config%\bzip2%dllsuffix%.dll osmium-tool-bin
+  - 7z a c:\projects\osmium-tool\osmium_%config%_%platform%.zip osmium-tool-bin -tzip
+
+artifacts:
+- path: osmium_%config%_%platform%.zip
+

--- a/build-appveyor.bat
+++ b/build-appveyor.bat
@@ -48,7 +48,7 @@ SET CMAKE_CMD=cmake .. -LA -G "Visual Studio 14 Win64" ^
 -DEXPAT_INCLUDE_DIR=C:/projects/expat.v140.2.2.5/build/native/include ^
 -DEXPAT_LIBRARY=C:/projects/expat.v140.2.2.5/build/native/lib/x64/%config%/libexpat%libpostfix%.lib ^
 -DBZIP2_INCLUDE_DIR=C:/projects/bzip2.v140.1.0.6.9/build/native/include ^
--DBZIP2_LIBRARIES=C:/projects/bzip2.v140.1.0.6.9/build/native/lib/x64/%config%/libbz2%libpostfix%.lib ^
+-DBZIP2_LIBRARIES=C:/projects/bzip2.v140.1.0.6.9/build/native/lib/x64/MT-%config%/libbz2%libpostfix%.lib ^
 -DBoost_USE_STATIC_LIBS=ON
 
 ECHO calling^: %CMAKE_CMD%


### PR DESCRIPTION
Added some after_build and artifacts instructions to appveyor.yml, so we can finally create windows binaries again via AppVeyor. Tested on Win 10 (Convert osm xml to pbf, open pbf in JOSM).

See https://ci.appveyor.com/project/mmd-osm/osmium-tool/build/1.0.10 for Debug/Release binaries example.

Maybe you want to move some of the after_build instructions to build-appveyor.bat to keep all version stuff in one file. I was also wondering a bit why you were using the non-MT version for bzip2. Is this intentional?

Fixes #59