### PR TITLE
Fix spelling of geometry-types option

### DIFF
--- a/man/osmium-export.md
+++ b/man/osmium-export.md
@@ -61,7 +61,7 @@ files created with JOSM).
     are ignored and the features are omitted from the output. If this option
     is set, any error will immediately stop the program.
 
---geometry-type=TYPES
+--geometry-types=TYPES
 :   Specify the geometry types that should be written out. Usually all created
     geometries (points, linestrings, and (multi)polygons) are written to the
     output, but you can restrict the types using this option. TYPES is a


### PR DESCRIPTION
Refs https://github.com/osmcode/osmium-tool/commit/5b0469bec382d697b0c86adcb37627f2abeef774

/cc @joto 