### PR TITLE
Fix spelling errors.

### DIFF
--- a/man/osmium-export.md
+++ b/man/osmium-export.md
@@ -263,7 +263,7 @@ false
 :   No tags match.
 
 Array
-:   The array contains one or more expressions as descibed in the FILTER
+:   The array contains one or more expressions as described in the FILTER
     EXPRESSION section.
 
 null

--- a/man/osmium-file-formats.md
+++ b/man/osmium-file-formats.md
@@ -95,7 +95,7 @@ Here are some examples:
 :   PBF format.
 
 `pbf,add_metadata=false`
-:   PBF format, dont' write metadata
+:   PBF format, don't write metadata
 
 `osm.bz2`
 :   XML format, compressed with bzip2.


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build:

 * dont'    -> don't
 * descibed -> described