### PR TITLE
fix osmium input-format typo from `--F` to `-F`

### DIFF
--- a/man/osmium-file-formats.md
+++ b/man/osmium-file-formats.md
@@ -60,7 +60,7 @@ STDOUT, or because you have an unusual file name, you have to set the format
 manually. You can also set the format manually if you want to specify special
 format options.
 
-Most **osmium** commands support the **--input-format** (**--F**) and
+Most **osmium** commands support the **--input-format** (**-F**) and
 **--output-format** (**-f**) options to set the format. They take a
 comma-separated list of arguments, the first is the format, further arguments
 set additional options.


### PR DESCRIPTION
fix a small typo  (   from `--F` to `-F` )


|       | text
|----  | --------------------------------------------------------------------------------------------------
|from|  `Most **osmium** commands support the **--input-format** (**--F**) and`
|to    |   `Most **osmium** commands support the **--input-format** (**-F**) and`