### PR TITLE
Adapt Postgres types in help message

### DIFF
--- a/src/export/export_format_pg.cpp
+++ b/src/export/export_format_pg.cpp
@@ -236,13 +236,13 @@ void ExportFormatPg::debug_output(osmium::VerboseOutput& out, const std::string&
     if (options().unique_id == unique_id_type::counter) {
         out << "    id        BIGINT PRIMARY KEY,\n";
     } else if (options().unique_id == unique_id_type::type_id) {
-        out << "    id        VARCHAR PRIMARY KEY,\n";
+        out << "    id        TEXT PRIMARY KEY,\n";
     }
 
-    out << "    geom      GEOMETRY,\n";
+    out << "    geom      GEOMETRY, -- or GEOGRAPHY\n";
 
     if (!options().type.empty()) {
-        out << "    osm_type  VARCHAR,\n";
+        out << "    osm_type  TEXT,\n";
     }
 
     if (!options().id.empty()) {
@@ -262,7 +262,7 @@ void ExportFormatPg::debug_output(osmium::VerboseOutput& out, const std::string&
     }
 
     if (!options().user.empty()) {
-        out << "    user      VARCHAR,\n";
+        out << "    user      TEXT,\n";
     }
 
     if (!options().timestamp.empty()) {
@@ -273,7 +273,7 @@ void ExportFormatPg::debug_output(osmium::VerboseOutput& out, const std::string&
         out << "    way_nodes BIGINT[],\n";
     }
 
-    out << "    tags      JSON -- or JSONB\n";
+    out << "    tags      JSONB -- or JSON, or TEXT\n";
     out << ");\n";
     out << "Then load data with something like this:\n";
     out << "\\copy osmdata FROM '" << filename << "'\n";


### PR DESCRIPTION
GEOGRAPHY is also compatible with EPSG:4326 WKBs, if someone needs true KNN lookups that may be a win for them.

TEXT is recommended spelling of unconstrained VARCHAR in Postgres.

JSONB is cooler than JSON for fields access. If you only need to store JSON for passing further into some non-SQL system and don't plan querying on it, TEXT will suffice and skip extra JSON validity check.