### PR TITLE
sample postgres SQL to create table needs to quote user

### DIFF
--- a/src/export/export_format_pg.cpp
+++ b/src/export/export_format_pg.cpp
@@ -318,7 +318,7 @@ void ExportFormatPg::debug_output(osmium::VerboseOutput& out, const std::string&
     }
 
     if (!options().user.empty()) {
-        out << "    user      TEXT,\n";
+        out << "    \"user\"      TEXT,\n";
     }
 
     if (!options().timestamp.empty()) {


### PR DESCRIPTION
```
# create table test (user TEXT);
ERROR:  syntax error at or near "user"
LINE 1: create table test (user TEXT);
# create table test ("user" TEXT);
CREATE TABLE
```

I assume with C++ this is the correct syntax.