### PR TITLE
AND option for tags-filter

### DIFF
--- a/man/osmium-tags-filter.md
+++ b/man/osmium-tags-filter.md
@@ -135,9 +135,11 @@ first and last node are the same) with 4 or more nodes and for all relations
 that have an additional "type=multipolygon" or "type=boundary" tag.
 
 By default, objects that match any of the expressions are written to the output.
-That is, **n/shop n/amenity** would match nodes with either tag. Use the
+That is, "n/shop n/amenity" would match nodes with either tag. Use the
 **-a/\--and** to require matching all of the expressions. For example,
 the same expressions would match only nodes with both tags present at once.
+Note that each type is matched separately: "highway w/name" would match all
+objects with a `highway` tag, but for ways it would require a non-empty name.
 
 
 # DIAGNOSTICS

--- a/man/osmium-tags-filter.md
+++ b/man/osmium-tags-filter.md
@@ -42,6 +42,10 @@ change files.
 -i, \--invert-match
 :   Invert the sense of matching. Exclude all objects with matching tags.
 
+-a, \--and
+:   Reqire objects of each type to match all the filter expressions for that
+    type simultaneously.
+
 -R, \--omit-referenced
 :   Omit the nodes referenced from matching ways and members referenced from
     matching relations.
@@ -130,6 +134,11 @@ turned into a (multi)polygon. This is the case for all closed ways (where the
 first and last node are the same) with 4 or more nodes and for all relations
 that have an additional "type=multipolygon" or "type=boundary" tag.
 
+By default, objects that match any of the expressions are written to the output.
+That is, **n/shop n/amenity** would match nodes with either tag. Use the
+**-a/\--and** to require matching all of the expressions. For example,
+the same expressions would match only nodes with both tags present at once.
+
 
 # DIAGNOSTICS
 
@@ -167,6 +176,15 @@ Get all nodes and ways with a `highway` tag and all relations tagged with
 
     osmium tags-filter -o filtered.osm.pbf planet.osm.pbf \
         nw/highway r/type=restriction
+
+Get all named roads:
+
+    osmium tags-filter -a -o roads.osm.pbf berlin.osm.pbf w/highway w/name
+
+Get all addressed buildings except `building=yes`:
+
+    osmium tags-filter -a -o building.osm.pbf berlin.osm.pbf \
+        a/addr:housenumber a/building!=yes
 
 
 # SEE ALSO

--- a/src/command_tags_filter.hpp
+++ b/src/command_tags_filter.hpp
@@ -51,6 +51,7 @@ class CommandTagsFilter : public Command, public with_single_osm_input, public w
     bool m_add_referenced_objects = true;
     bool m_invert_match = false;
     bool m_remove_tags = false;
+    bool m_all_filters = false;
 
     osmium::osm_entity_bits::type get_needed_types() const;
 

--- a/test/tags-filter/CMakeLists.txt
+++ b/test/tags-filter/CMakeLists.txt
@@ -12,6 +12,7 @@ endfunction()
 
 check_tags_filter(node        ""      input.osm n/amenity output-amenity.osm)
 check_tags_filter(node-R      "-R"    input.osm n/amenity output-amenity.osm)
+check_tags_filter(node-a      "-a"    input.osm n/amenity output-amenity.osm)
 
 check_tags_filter(highway-R   "-R"    input.osm w/highway output-highway-R.osm)
 check_tags_filter(note-R      "-R"    input.osm note output-note-R.osm)
@@ -19,8 +20,15 @@ check_tags_filter(note-R      "-R"    input.osm note output-note-R.osm)
 check_tags_filter(note-iR     "-i -R" input.osm note output-note-iR.osm)
 
 check_tags_filter(highway     ""      input.osm w/highway output-highway.osm)
+check_tags_filter(highway-a   "-a"    input.osm w/highway output-highway.osm)
 
 check_tags_filter(highway-i   "-i"    input.osm w/highway output-highway-i.osm)
+check_tags_filter(highway-ai  "-i -a" input.osm w/highway output-highway-i.osm)
+
+check_tags_filter(highway-wnote   ""      input.osm w/highway w/note output-highway.osm)
+check_tags_filter(highway-note    ""      input.osm w/highway note output-highway.osm)
+check_tags_filter(highway-wnote-a "-a"    input.osm w/highway w/note output-highway-note.osm)
+check_tags_filter(highway-note-aR "-a -R" input.osm w/highway note output-note-R.osm)
 
 check_tags_filter(highway-n-i "-i"    input-nodes.osm w/highway output-nodes-highway-i.osm)
 

--- a/test/tags-filter/output-highway-note.osm
+++ b/test/tags-filter/output-highway-note.osm
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" upload="false" generator="test">
+  <node id="12" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
+  <node id="13" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="4" lon="1"/>
+  <way id="21" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <tag k="highway" v="residential"/>
+    <tag k="note" v="test"/>
+  </way>
+</osm>

--- a/zsh_completion/_osmium
+++ b/zsh_completion/_osmium
@@ -402,6 +402,8 @@ _osmium-tags-filter() {
         '(-e)--expressions[read filter expressions from file]:filter expressions file:_files' \
         '(--invert-match)-i[invert the sense of matching, exclude objects with matching tags]' \
         '(-i)--invert-match[invert the sense of matching, exclude objects with matching tags]' \
+        '(--and)-a[Treat space-separated filters as AND, not OR]' \
+        '(-a)--and[Treat space-separated filters as AND, not OR]' \
         '(--omit-referenced)-R[omit referenced objects]' \
         '(-R)--omit-referenced[omit referenced objects]' \
         '(--progress)--no-progress[disable progress bar]' \


### PR DESCRIPTION
I needed to extract all names roads (or addressed buildings, whatever), and discovered that there is no non-outdated tool that can do that. Osmosis is obsolete, osmfilter cannot process pbf, osmium-filter is still experimental. A common answer to that was to filter on one of the tags, and then filter on another, or to write a filtering script by hand.

So I made a little tweak to the osmium-tool to treat multiple filter expressions as joined by an AND clause, not OR. E.g. `w/highway w/name` would produce ways that have both tags set. These clauses are considered only for respective types, so `w/highway w/name r/type=restriction` would produce named roads and turn restrictions.

The change might be sub-optimal and look like a hack. Feel free to close this PR if it cannot be merged.

Requires https://github.com/osmcode/libosmium/pull/326 to function.