### PR TITLE
Make attributes an option for osmium export

### DIFF
--- a/man/osmium-export.md
+++ b/man/osmium-export.md
@@ -76,6 +76,11 @@ files created with JOSM).
     output, but you can restrict the types using this option. TYPES is a
     comma-separated list of the types ("point", "linestring", and "polygon").
 
+-a, \--attributes=ATTRS
+:   In addition to tags, also export attributes specified in this comma-separated
+    list. By default, none are exported. See the **ATTRIBUTES** section below
+    for the known attributes list and an explanation.
+
 -i, \--index-type=TYPE
 :   Set the index type. For details see the **osmium-index-types**(5) man
     page.
@@ -259,6 +264,10 @@ each attribute you are interested in, the value can be either `false` (do not
 output this attribute), `true` (output this attribute with the attribute name
 prefixed by the `@` sign) or any string, in which case the string will be used
 as the attribute name.
+
+Another option is to specify attributes list in a comma-separated string
+for the **\--attributes/-a** command-line option. This way you cannot
+control column names, but also you won't have to create a config file.
 
 Depending on your choice of values for the `attributes` objects, attributes
 can have the same name as tag keys. If this is the case, the conflicting tag

--- a/src/command_export.cpp
+++ b/src/command_export.cpp
@@ -272,6 +272,7 @@ bool CommandExport::setup(const std::vector<std::string>& arguments) {
     ("show-errors,e", "Output any geometry errors on STDOUT")
     ("stop-on-error,E", "Stop on the first error encountered")
     ("show-index-types,I", "Show available index types")
+    ("attributes,a", po::value<std::string>(), "Comma-separated list of attributes to add to the output (default: none)")
     ("omit-rs,r", "Do not print RS (record separator) character when using JSON Text Sequences")
     ;
 
@@ -409,6 +410,31 @@ bool CommandExport::setup(const std::vector<std::string>& arguments) {
         }
         if (m_geometry_types.empty()) {
             throw argument_error{"No geometry types in --geometry-types option."};
+        }
+    }
+
+    if (vm.count("attributes")) {
+        const auto attrs = osmium::split_string(vm["attributes"].as<std::string>(), ',');
+        for (const auto& attr : attrs) {
+            if (attr == "type") {
+                m_options.type = "@type";
+            } else if (attr == "id") {
+                m_options.id = "@id";
+            } else if (attr == "version") {
+                m_options.version = "@version";
+            } else if (attr == "changeset") {
+                m_options.changeset = "@changeset";
+            } else if (attr == "timestamp") {
+                m_options.timestamp = "@timestamp";
+            } else if (attr == "uid") {
+                m_options.uid = "@uid";
+            } else if (attr == "user") {
+                m_options.user = "@user";
+            } else if (attr == "way_nodes") {
+                m_options.way_nodes = "@way_nodes";
+            } else {
+                throw argument_error{"Unknown attribute in --attributes option: " + attr + "."};
+            }
         }
     }
 

--- a/test/export/CMakeLists.txt
+++ b/test/export/CMakeLists.txt
@@ -26,6 +26,8 @@ set_tests_properties(export-error-area PROPERTIES WILL_FAIL true)
 
 #-----------------------------------------------------------------------------
 
+check_export(attributes  "-E -f text -a id" way.osm way-all.txt)
+
 check_export(c-empty-empty-n "-E -f text --keep-untagged -c export/config-empty-empty.json" way.osm way-all-n.txt)
 set_tests_properties(export-c-empty-empty-n PROPERTIES ENVIRONMENT osmium_cmake_stderr=ignore)
 check_export(c-empty-empty   "-E -f text                 -c export/config-empty-empty.json" way.osm way-all.txt)


### PR DESCRIPTION
The `osmium export` command currently does not output object ids or any other metadata unless you write a json config file. That's unfortunate when you just want a one-off export with ids. I don't see any reason for not making it into a command-line options, so I did that.