### PR TITLE
Add nested relations references

### DIFF
--- a/src/command_tags_filter.cpp
+++ b/src/command_tags_filter.cpp
@@ -260,6 +260,8 @@ bool CommandTagsFilter::find_relations_in_relations() {
                         m_referenced_ids(osmium::item_type::node).set(member.positive_ref());
                     } else if (member.type() == osmium::item_type::way) {
                         m_referenced_ids(osmium::item_type::way).set(member.positive_ref());
+                    } else if (member.type() == osmium::item_type::relation) {
+                        m_referenced_ids(osmium::item_type::relation).set(member.positive_ref());
                     }
                 }
             }

--- a/test/tags-filter/CMakeLists.txt
+++ b/test/tags-filter/CMakeLists.txt
@@ -19,6 +19,7 @@ check_tags_filter(note-R      "-R"    input.osm note output-note-R.osm)
 check_tags_filter(note-iR     "-i -R" input.osm note output-note-iR.osm)
 
 check_tags_filter(highway     ""      input.osm w/highway output-highway.osm)
+check_tags_filter(site-nwr     ""      input.osm site output-highway-nwr.osm)
 
 check_tags_filter(highway-i   "-i"    input.osm w/highway output-highway-i.osm)
 

--- a/test/tags-filter/CMakeLists.txt
+++ b/test/tags-filter/CMakeLists.txt
@@ -19,7 +19,7 @@ check_tags_filter(note-R      "-R"    input.osm note output-note-R.osm)
 check_tags_filter(note-iR     "-i -R" input.osm note output-note-iR.osm)
 
 check_tags_filter(highway     ""      input.osm w/highway output-highway.osm)
-check_tags_filter(site-nwr     ""      input.osm site output-highway-nwr.osm)
+check_tags_filter(site-nwr    ""      input.osm site output-site-nwr.osm)
 
 check_tags_filter(highway-i   "-i"    input.osm w/highway output-highway-i.osm)
 

--- a/test/tags-filter/output-highway-i.osm
+++ b/test/tags-filter/output-highway-i.osm
@@ -23,4 +23,8 @@
     <member type="way" ref="20" role="m2"/>
     <tag k="note" v="test"/>
   </relation>
+  <relation id="31" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="relation" ref="30" role="m1"/>
+    <tag k="site" v="foo"/>
+  </relation>
 </osm>

--- a/test/tags-filter/output-highway-it.osm
+++ b/test/tags-filter/output-highway-it.osm
@@ -22,4 +22,8 @@
     <member type="way" ref="20" role="m2"/>
     <tag k="note" v="test"/>
   </relation>
+  <relation id="31" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="relation" ref="30" role="m1"/>
+    <tag k="site" v="foo"/>
+  </relation>
 </osm>

--- a/test/tags-filter/output-note-iR.osm
+++ b/test/tags-filter/output-note-iR.osm
@@ -18,4 +18,8 @@
     <nd ref="12"/>
     <tag k="highway" v="primary"/>
   </way>
+  <relation id="31" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <member type="relation" ref="30" role="m1"/>
+    <tag k="site" v="foo"/>
+  </relation>
 </osm>

--- a/test/tags-filter/output-site-nwr.osm
+++ b/test/tags-filter/output-site-nwr.osm
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<osm version="0.6" upload="false" generator="testdata">
+<osm version="0.6" upload="false" generator="test">
   <node id="10" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="1"/>
   <node id="11" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="2" lon="1">
     <tag k="barrier" v="gate"/>

--- a/test/tags-filter/output-site-nwr.osm
+++ b/test/tags-filter/output-site-nwr.osm
@@ -5,24 +5,11 @@
     <tag k="barrier" v="gate"/>
   </node>
   <node id="12" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
-  <node id="13" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="4" lon="1"/>
-  <node id="14" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="5" lon="1">
-    <tag k="amenity" v="post_box"/>
-  </node>
-  <node id="15" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="6" lon="1">
-    <tag k="highway" v="traffic_signals"/>
-  </node>
   <way id="20" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
     <nd ref="10"/>
     <nd ref="11"/>
     <nd ref="12"/>
     <tag k="highway" v="primary"/>
-  </way>
-  <way id="21" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
-    <nd ref="12"/>
-    <nd ref="13"/>
-    <tag k="highway" v="residential"/>
-    <tag k="note" v="test"/>
   </way>
   <relation id="30" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
     <member type="node" ref="12" role="m1"/>


### PR DESCRIPTION
Fix the nested relations lookup so that "All objects referenced [from those objects] will also be added to the output unless the option  --omit-refer‐ enced/-R is used. "