### PR TITLE
Fix point-in-polygon-check in extract command

### DIFF
--- a/src/extract/extract_polygon.cpp
+++ b/src/extract/extract_polygon.cpp
@@ -139,7 +139,7 @@ bool ExtractPolygon::contains(const osmium::Location& location) const noexcept {
             const int64_t tx = int64_t(location.x())        - int64_t(segment.second().x());
             const int64_t ty = int64_t(location.y())        - int64_t(segment.second().y());
 
-            const bool comp = tx * ay < ax * ty;
+            const bool comp = tx * ay <= ax * ty;
 
             if ((ay > 0) == comp) {
                 inside = !inside;


### PR DESCRIPTION
More nodes directly on the boundary should now be inside the polygon.

See #220