### PR TITLE
Added support for reading extract config json from stdin

### DIFF
--- a/src/command_extract.cpp
+++ b/src/command_extract.cpp
@@ -279,7 +279,7 @@ void CommandExtract::set_directory(const std::string& directory) {
 
 void CommandExtract::parse_config_file() {
     std::ifstream config_file{m_config_file_name};
-    rapidjson::IStreamWrapper stream_wrapper{config_file};
+    rapidjson::IStreamWrapper stream_wrapper{(m_config_file_name == "-")? std::cin : config_file};
 
     rapidjson::Document doc;
     if (doc.ParseStream<(rapidjson::kParseCommentsFlag | rapidjson::kParseTrailingCommasFlag)>(stream_wrapper).HasParseError()) {


### PR DESCRIPTION
Many tools support the option to read configs/lists from stdin instead of physical file, when '-' specified as filename. It's useful when extract config json is generated at runtime and it is not needed after extraction.