### PR TITLE
Require Osmium 2.17.0 for is_false.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ option(BUILD_TESTING "Build the tests" ON)
 find_package(Boost 1.55.0 REQUIRED COMPONENTS program_options)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
-find_package(Osmium 2.16.0 REQUIRED COMPONENTS io)
+find_package(Osmium 2.17.0 REQUIRED COMPONENTS io)
 include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS})
 
 


### PR DESCRIPTION
The osmium-tool Debian package failed to build with 2.16.0-1 for bullseye-backports:
```
error: 'const class osmium::util::Options' has no member named 'is_false'
```
To fix this at least libosmium 2.17.0 is required.