### PR TITLE
Fix failing assert due to off-by-one error

### DIFF
--- a/src/extract/extract_polygon.cpp
+++ b/src/extract/extract_polygon.cpp
@@ -81,7 +81,7 @@ ExtractPolygon::ExtractPolygon(const osmium::io::File& output_file, const std::s
 
     m_bands.resize(num_bands + 1);
 
-    m_dy = (y_max() - y_min()) / num_bands;
+    m_dy = (y_max() - y_min() + num_bands - 1) / num_bands;
 
     // put segments into the bands they overlap
     for (const auto& segment : segments) {


### PR DESCRIPTION
While working with some OSM border data as a polygon I encountered a segmentation fault while using `osmium extract`.

See example values
```
m_dy = (y_max() - y_min()) / num_bands
3811 = (437903881 - 399786994) / 10000
```
In this case m_dy would be `3811.6887` if it were not an `int32_t`. The result of this is that `m_dy` can cause `band_max` to go over the initially set `max_bands` by 1.
```
(437903881 - 399786994) / 3811 = 10001.8071372
```
This fixes that by "rounding" `m_dy`.