### PR TITLE
Fix ID comparison in `osmium merge` to match `osmium sort` behavior

### DIFF
--- a/src/command_merge.cpp
+++ b/src/command_merge.cpp
@@ -35,6 +35,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <osmium/memory/buffer.hpp>
 #include <osmium/osm/entity_bits.hpp>
 #include <osmium/osm/object.hpp>
+#include <osmium/osm/object_comparisons.hpp>
 #include <osmium/util/verbose_output.hpp>
 
 #include <boost/program_options.hpp>
@@ -146,10 +147,11 @@ namespace {
                 return true;
             }
 
-            if (m_iterator->id() < m_last_id) {
+            static constexpr osmium::id_order id_cmp{};
+            if (id_cmp(m_iterator->id(), m_last_id)) {
                 throw std::runtime_error{"Objects in input file '" + m_name + "' out of order (smaller ids must come first)."};
             }
-            if (m_iterator->id() > m_last_id) {
+            if (id_cmp(m_last_id, m_iterator->id())) {
                 m_last_id = m_iterator->id();
                 m_last_version = m_iterator->version();
                 return true;


### PR DESCRIPTION
### Description

When using `osmium sort`, object IDs are sorted according to the following rule:

> Compare two object IDs. Order is as follows: `0` first, then negative IDs, then positive IDs — both ordered by their absolute values.
> (See [object_comparisons.hpp#L83-L110](https://github.com/osmcode/libosmium/blob/master/include/osmium/osm/object_comparisons.hpp#L83-L110))

However, in `osmium merge`, the order validation currently relies on a plain numerical comparison of IDs.
As a result, `osmium merge` may fail when merging files produced by `osmium sort` if negative IDs are present.

### Proposed fix

This pull request addresses the mismatch by reusing the `id_order` comparator defined in
[`object_comparisons.hpp`](https://github.com/osmcode/libosmium/blob/master/include/osmium/osm/object_comparisons.hpp).
Specifically, it replaces the simple numeric comparison in `osmium merge` with `id_order`, ensuring consistency with `osmium sort`.