### PR TITLE
bug-fix: nodes that start with a node outside the region but have a node in the region should be included in simple extract

### DIFF
--- a/src/extract/strategy_simple.cpp
+++ b/src/extract/strategy_simple.cpp
@@ -77,8 +77,8 @@ namespace strategy_simple {
                 if (e->node_ids.get(nr.positive_ref())) {
                     e->write(way);
                     e->way_ids.set(way.positive_id());
+                    return;
                 }
-                return;
             }
         }
 

--- a/test/extract/CMakeLists.txt
+++ b/test/extract/CMakeLists.txt
@@ -64,3 +64,5 @@ check_extract_opl(antimeridian-alaska-west-poly w46113981.osm w46113981.opl "--p
 check_extract_opl(antimeridian-alaska-east-json-no-feature w42394837.osm w42394837.opl "--polygon=extract/polygon-us-alaska-no-feature.geojson")
 
 #-----------------------------------------------------------------------------
+check_extract(simple_way_starts_outside input-way-starts-outside.osm output-simple-way-starts-outside.osm "-s simple")
+

--- a/test/extract/input-way-starts-outside.osm
+++ b/test/extract/input-way-starts-outside.osm
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" upload="false" generator="testdata">
+  <node id="100" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="1" lon="5"/>
+  <node id="101" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="2" lon="1"/>
+  <node id="102" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
+  <way id="200" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="100"/>
+    <nd ref="101"/>
+    <nd ref="102"/>
+    <tag k="highway" v="residential"/>
+  </way>
+</osm>
+

--- a/test/extract/output-simple-way-starts-outside.osm
+++ b/test/extract/output-simple-way-starts-outside.osm
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+  <node id="101" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="2" lon="1"/>
+  <node id="102" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1" lat="3" lon="1"/>
+  <way id="200" version="1" timestamp="2015-01-01T01:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="100"/>
+    <nd ref="101"/>
+    <nd ref="102"/>
+    <tag k="highway" v="residential"/>
+  </way>
+</osm>


### PR DESCRIPTION
Manual describes the `simple` strategy's output as
["All ways that have at least one node inside the region are included" ](https://osmcode.org/osmium-tool/manual.html#filtering-by-tags:~:text=All%20ways%20that%20have%20at%20least%20one%20node%20inside%20the%20region%20are%20included)

However, existing code checks only the start/first node of the way and exclude the ways that have nodes inside the region.