### PR TITLE
extract: scan way nodes once across all extracts in complete_ways pass 1

### DIFF
--- a/src/extract/strategy.hpp
+++ b/src/extract/strategy.hpp
@@ -104,9 +104,7 @@ class Pass {
                         break;
                     case osmium::item_type::way:
                         self().way(static_cast<const osmium::Way&>(object));
-                        for (auto& e : extracts()) {
-                            self().eway(&e, static_cast<const osmium::Way&>(object));
-                        }
+                        self().eway_all(extracts(), static_cast<const osmium::Way&>(object));
                         break;
                     case osmium::item_type::relation:
                         self().relation(static_cast<const osmium::Relation&>(object));
@@ -153,6 +151,15 @@ protected:
     }
 
     void erelation(extract_data*, const osmium::Relation&) {
+    }
+
+    // Default implementation: call eway() for each extract separately.
+    // Subclasses may override this to process all extracts in a single
+    // pass over way.nodes().
+    void eway_all(std::vector<extract_data>& exts, const osmium::Way& way) {
+        for (auto& e : exts) {
+            self().eway(&e, way);
+        }
     }
 
 public:

--- a/src/extract/strategy_complete_ways.cpp
+++ b/src/extract/strategy_complete_ways.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <osmium/handler/check_order.hpp>
 #include <osmium/util/file.hpp>
 
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
 #include <vector>
@@ -96,6 +97,55 @@ namespace strategy_complete_ways {
                         e->extra_node_ids.set(nr.ref());
                     }
                     return;
+                }
+            }
+        }
+
+        // Override that scans way.nodes() at most twice for all extracts
+        // combined instead of up to twice per extract as the default does.
+        // Uses a uint64_t bitmask so falls back to the default per-extract
+        // eway() loop when there are more than 64 extracts.
+        // Pass A finds which extracts claim this way.
+        // Pass B records all node refs into extra_node_ids for matched extracts.
+        void eway_all(std::vector<extract_data>& exts, const osmium::Way& way) {
+            const std::size_t n = exts.size();
+
+            if (n > 64) {
+                for (auto& e : exts) {
+                    self().eway(&e, way);
+                }
+                return;
+            }
+            std::uint64_t found_mask = 0;
+            std::size_t remaining = n;
+
+            for (const auto& nr : way.nodes()) {
+                const auto node_id = nr.positive_ref();
+                for (std::size_t i = 0; i < n; ++i) {
+                    if (!(found_mask & (std::uint64_t{1} << i)) &&
+                        exts[i].node_ids.get(node_id)) {
+                        found_mask |= std::uint64_t{1} << i;
+                        exts[i].way_ids.set(way.positive_id());
+                        if (--remaining == 0) {
+                            break;
+                        }
+                    }
+                }
+                if (remaining == 0) {
+                    break;
+                }
+            }
+
+            if (found_mask == 0) {
+                return;
+            }
+
+            for (const auto& nr : way.nodes()) {
+                const auto node_ref = nr.ref();
+                for (std::size_t i = 0; i < n; ++i) {
+                    if (found_mask & (std::uint64_t{1} << i)) {
+                        exts[i].extra_node_ids.set(node_ref);
+                    }
                 }
             }
         }


### PR DESCRIPTION
See #312.

In Pass 1 of `--strategy=complete_ways`, `eway()` is called independently for
each extract on every way. This means `way.nodes()` is scanned up to twice per
extract, giving up to 2N scans total for N extracts.

This adds an `eway_all()` override in `strategy_complete_ways` that scans
`way.nodes()` at most twice regardless of N. A `uint64_t` bitmask tracks which
extracts have claimed the way in the first pass; the second pass then records
all node refs into `extra_node_ids` for matched extracts only.

When there are more than 64 extracts the method falls back to the original
per-extract `eway()` loop.

### Benchmark

japan-260423.osm.pbf (~1 GB), 8-tile extraction:

| Version | Elapsed | vs baseline |
|---|---:|---:|
| upstream | 1m 29s | — |
| this PR | 1m 25s | -4% |

planet-260413.osm.pbf (~86 GB), 16-tile extraction:

| Version | Elapsed | vs baseline |
|---|---:|---:|
| upstream | 51m 36s | — |
| this PR | 49m 27s | -4% |

Output verified to be identical to the upstream result for all tiles.