### PR TITLE
extract: write output asynchronously using a background thread per extract

### DIFF
--- a/src/extract/extract.cpp
+++ b/src/extract/extract.cpp
@@ -29,28 +29,108 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <utility>
 
-void Extract::open_file(const osmium::io::Header& header, osmium::io::overwrite output_overwrite, osmium::io::fsync sync, OptionClean const* clean) {
+void Extract::writer_loop() {
+    try {
+        while (true) {
+            std::unique_lock<std::mutex> lock{m_mutex};
+            m_cv.wait(lock, [this]{ return m_flush_pending || m_shutdown; });
+
+            if (m_shutdown && !m_flush_pending) {
+                break;
+            }
+
+            // Reset m_flush_pending under the lock so that swap_and_flush()
+            // can observe the transition to false only after the buffer has
+            // been moved out and is no longer shared.
+            m_clean->apply_to(m_flush_buffer);
+            auto buf = std::move(m_flush_buffer);
+            m_flush_buffer = osmium::memory::Buffer{buffer_size,
+                                                     osmium::memory::Buffer::auto_grow::no};
+            m_flush_pending = false;
+            lock.unlock();
+            m_cv.notify_one();
+
+            // The osmium Writer call (compression + I/O) runs outside the lock
+            // so the main thread can keep filling m_fill_buffer concurrently.
+            (*m_writer)(std::move(buf));
+        }
+    } catch (...) {
+        std::unique_lock<std::mutex> lock{m_mutex};
+        m_writer_exception = std::current_exception();
+        m_flush_pending = false;
+        m_shutdown = true;
+        lock.unlock();
+        m_cv.notify_all();
+    }
+}
+
+void Extract::check_writer_exception() {
+    if (m_writer_exception) {
+        std::rethrow_exception(m_writer_exception);
+    }
+}
+
+void Extract::swap_and_flush() {
+    std::unique_lock<std::mutex> lock{m_mutex};
+    m_cv.wait(lock, [this]{ return !m_flush_pending || m_shutdown; });
+    check_writer_exception();
+
+    std::swap(m_fill_buffer, m_flush_buffer);
+    m_fill_buffer = osmium::memory::Buffer{buffer_size,
+                                           osmium::memory::Buffer::auto_grow::no};
+    m_flush_pending = true;
+    lock.unlock();
+    m_cv.notify_one();
+}
+
+void Extract::open_file(const osmium::io::Header& header,
+                        osmium::io::overwrite output_overwrite,
+                        osmium::io::fsync sync,
+                        OptionClean const* clean) {
     m_clean = clean;
-    m_writer = std::make_unique<osmium::io::Writer>(m_output_file, header, output_overwrite, sync);
+    m_writer = std::make_unique<osmium::io::Writer>(m_output_file, header,
+                                                     output_overwrite, sync);
+    m_writer_thread = std::thread{&Extract::writer_loop, this};
 }
 
 void Extract::close_file() {
-    if (m_writer) {
-        if (m_buffer.committed() > 0) {
-            m_clean->apply_to(m_buffer);
-            (*m_writer)(std::move(m_buffer));
+    if (!m_writer) {
+        return;
+    }
+
+    if (m_fill_buffer.committed() > 0) {
+        swap_and_flush();
+    }
+
+    {
+        std::unique_lock<std::mutex> lock{m_mutex};
+        m_cv.wait(lock, [this]{ return !m_flush_pending || m_shutdown; });
+        check_writer_exception();
+        m_shutdown = true;
+    }
+    m_cv.notify_one();
+    m_writer_thread.join();
+
+    check_writer_exception();
+    m_writer->close();
+}
+
+Extract::~Extract() {
+    if (m_writer_thread.joinable()) {
+        {
+            std::lock_guard<std::mutex> lock{m_mutex};
+            m_shutdown = true;
         }
-        m_writer->close();
+        m_cv.notify_one();
+        m_writer_thread.join();
     }
 }
 
 void Extract::write(const osmium::memory::Item& item) {
-    if (m_buffer.capacity() - m_buffer.committed() < item.padded_size()) {
-        m_clean->apply_to(m_buffer);
-        (*m_writer)(std::move(m_buffer));
-        m_buffer = osmium::memory::Buffer{buffer_size, osmium::memory::Buffer::auto_grow::no};
+    if (m_fill_buffer.capacity() - m_fill_buffer.committed() < item.padded_size()) {
+        swap_and_flush();
     }
-    m_buffer.push_back(item);
+    m_fill_buffer.push_back(item);
 }
 
 std::string Extract::envelope_as_text() const {
@@ -58,4 +138,3 @@ std::string Extract::envelope_as_text() const {
     ss << m_envelope;
     return ss.str();
 }
-

--- a/src/extract/extract.hpp
+++ b/src/extract/extract.hpp
@@ -29,12 +29,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <osmium/io/header.hpp>
 #include <osmium/io/writer.hpp>
 #include <osmium/io/writer_options.hpp>
+#include <osmium/memory/buffer.hpp>
 #include <osmium/memory/item.hpp>
 #include <osmium/osm/box.hpp>
 #include <osmium/osm/location.hpp>
 
+#include <condition_variable>
+#include <exception>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -46,20 +51,35 @@ class Extract {
     std::string m_description;
     std::vector<std::string> m_header_options;
     osmium::Box m_envelope;
-    osmium::memory::Buffer m_buffer{buffer_size, osmium::memory::Buffer::auto_grow::no};
+
+    // Double-buffering: the main thread fills m_fill_buffer while the writer
+    // thread flushes m_flush_buffer to disk asynchronously.
+    osmium::memory::Buffer m_fill_buffer{buffer_size, osmium::memory::Buffer::auto_grow::no};
+    osmium::memory::Buffer m_flush_buffer{buffer_size, osmium::memory::Buffer::auto_grow::no};
+
     std::unique_ptr<osmium::io::Writer> m_writer;
     const OptionClean* m_clean = nullptr;
+
+    std::thread m_writer_thread;
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    bool m_flush_pending = false;
+    bool m_shutdown = false;
+    std::exception_ptr m_writer_exception;
+
+    void writer_loop();
+    void swap_and_flush();
+    void check_writer_exception();
 
 public:
 
     Extract(const osmium::io::File& output_file, const std::string& description, const osmium::Box& envelope) :
         m_output_file(output_file),
         m_description(description),
-        m_envelope(envelope),
-        m_writer(nullptr) {
+        m_envelope(envelope) {
     }
 
-    virtual ~Extract() = default;
+    virtual ~Extract();
 
     const std::string& output() const noexcept {
         return m_output_file.filename();


### PR DESCRIPTION
See #312. Split from #313 as requested.

In `--strategy=complete_ways`, `Extract::write()` calls
`osmium::io::Writer::operator()(Buffer&&)` synchronously for each extract.
With N output files (e.g. 16 tiles for a z=2 planet split), the main thread
serialises the flush of each writer in sequence.

This patch adds a per-`Extract` background writer thread. The main thread
fills a front buffer; when full it swaps with the back buffer under a mutex
and returns immediately. The background thread drains the back buffer to
`osmium::io::Writer`. Exceptions are captured in `std::exception_ptr` and
re-thrown on the next foreground synchronisation point. The `Extract`
destructor joins the background thread before returning.

### Benchmark

All runs: `--strategy=complete_ways`, same output config, 32-core machine.

japan-260423.osm.pbf (~1 GB), 8-tile extraction:

| Version | Elapsed | vs upstream |
|---|---:|---:|
| upstream | 1m 29s | baseline |
| this PR | 1m 07s | -25% |

planet-260413.osm.pbf (~86 GB), 16-tile z=2 extraction:

| Version | Elapsed | vs upstream |
|---|---:|---:|
| upstream | 51m 36s | baseline |
| this PR | 42m 35s | -18% |

Output verified to be identical to the upstream result for all tiles.

### Note on the libosmium-side approach (re: #313)

In #313 the question was raised whether this belongs in libosmium so all
commands benefit. That approach was implemented and measured as a
per-`Writer` background encode thread on a libosmium branch:

japan-260423.osm.pbf, 8-tile:

| Version | Elapsed | vs upstream |
|---|---:|---:|
| upstream | 1m 29s | baseline |
| libosmium per-Writer async encode | 1m 13s | -18% |
| this PR (osmium-tool per-Extract) | 1m 07s | -25% |

planet-260413.osm.pbf, 16-tile:

| Version | Elapsed | vs upstream |
|---|---:|---:|
| upstream | 51m 36s | baseline |
| libosmium per-Writer async encode | 45m 41s | -11% |
| this PR (osmium-tool per-Extract) | 42m 35s | -18% |

The 7% gap is consistent across both scales. In PBF mode,
`Writer::write_buffer()` submits tasks to the libosmium thread pool and
returns quickly, so a per-`Writer` encode thread backgrounds only a small
slice of the call. Backgrounding the full `(*m_writer)(buffer)` call from
`Extract::write()` covers the broader call-site overhead across N concurrent
extracts.

Both approaches can coexist. Sharing the numbers so the placement decision
is informed by data.

### Note on exception safety (re: #313)

Acknowledged. Cross-thread state is limited to the two buffers swapped
under a single mutex. The `osmium::io::Writer` instance is owned exclusively
by the background thread after construction. Exceptions in the background
thread propagate to the foreground via `std::exception_ptr` and are re-thrown
at the next `write()` or `close()` call. Output correctness was verified by
per-tile object-count comparison against upstream (identical).

Specific test cases can be added if there is a scenario to cover.